### PR TITLE
Improve mobile layout and touch targets

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,62 @@
+.container {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.section {
+  background: #fff;
+  border: 1px solid #eaecef;
+  border-radius: 16px;
+  padding: 16px;
+  margin-top: 16px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.03);
+}
+
+.grid2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+.truncate {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.small {
+  font-size: 12px;
+  color: #6b7280;
+}
+
+@media (max-width: 768px) {
+  html,
+  body {
+    font-size: 16px;
+  }
+
+  .container {
+    padding: 16px;
+  }
+
+  .section {
+    padding: 12px;
+    border-radius: 16px;
+  }
+
+  .grid2 {
+    grid-template-columns: 1fr;
+  }
+
+  button,
+  input,
+  select,
+  textarea {
+    min-height: 44px;
+  }
+
+  button {
+    min-width: 44px;
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import {
   ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip,
   PieChart, Pie, Legend, Cell
 } from 'recharts';
+import './App.css';
 
 /** ========= 基本ユーティリティ ========= */
 
@@ -419,8 +420,7 @@ export default function App() {
         /** ====== 未ログイン画面 ====== */
   if (!session) {
     return (
-      <div className="container" style={{ padding: 24 }}>
-        <style>{styles}</style>
+      <div className="container">
         <h2>ログイン</h2>
         <form onSubmit={login}>
           <input
@@ -438,8 +438,6 @@ export default function App() {
   /** ====== ログイン後 UI ====== */
   return (
     <div className="container">
-      <style>{styles}</style>
-
       <h1>家計簿カテゴリ管理ミニアプリ</h1>
       <div style={{ marginBottom: 8 }}>
         <strong>{session.user.email}</strong>
@@ -755,14 +753,5 @@ function OthersRow({ row, onAdd }) {
     </tr>
   );
 }
-
-/** ====== 最小CSS ====== */
-const styles = `
-.container{max-width:1100px;margin:0 auto;padding:24px}
-.section{background:#fff;border:1px solid #eaecef;border-radius:12px;padding:16px;margin-top:16px;box-shadow:0 1px 2px rgba(0,0,0,.03)}
-.grid2{display:grid;grid-template-columns:1fr 1fr;gap:16px}
-.truncate{white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-.small{font-size:12px;color:#6b7280}
-`;
 
     


### PR DESCRIPTION
## Summary
- move section styling into new App.css
- add mobile-first styles and larger tap targets

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68985ba45e60832ea6649635481972b4