### PR TITLE
Add button-based period selector

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -78,6 +78,10 @@
   border-radius: 4px;
 }
 
+.period-selector { display: flex; gap: 8px; margin-bottom: 8px; }
+.period-selector button { flex: 1; }
+.period-selector button.active { font-weight: 600; text-decoration: underline; }
+
 @media (max-width: 768px) {
   html,
   body {
@@ -106,5 +110,13 @@
 
   button {
     min-width: 44px;
+  }
+
+  .period-selector {
+    position: sticky;
+    top: 0;
+    z-index: 20;
+    background: #fff;
+    padding: 8px 0;
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -502,19 +502,7 @@ export default function App() {
 
       {/* 3. 可視化 */}
       <AccordionSection title="3. 可視化">
-        <div className="small" style={{ marginBottom: 8 }}>
-          表示期間：
-          <select
-            value={period}
-            onChange={e => setPeriod(e.target.value)}
-            style={{ marginLeft: 6 }}
-          >
-            <option value="3m">最近3ヶ月</option>
-            <option value="6m">半年</option>
-            <option value="1y">1年</option>
-            <option value="all">全期間</option>
-          </select>
-        </div>
+        <PeriodSelector value={period} onChange={setPeriod} />
 
         <div className="grid2" style={{ height: 360 }}>
           {/* 月別総支出（万円単位） */}
@@ -647,6 +635,28 @@ export default function App() {
 } // <= App 閉じ
 
 /** ====== 小さな部品 ====== */
+
+function PeriodSelector({ value, onChange }) {
+  const options = [
+    { key: '3m', label: 'Last 3 months' },
+    { key: '6m', label: '6 months' },
+    { key: '1y', label: '1 year' },
+    { key: 'all', label: 'All' }
+  ];
+  return (
+    <div className="period-selector">
+      {options.map(opt => (
+        <button
+          key={opt.key}
+          className={value === opt.key ? 'active' : ''}
+          onClick={() => onChange(opt.key)}
+        >
+          {opt.label}
+        </button>
+      ))}
+    </div>
+  );
+}
 
 function RuleRow({ rule, onDelete }) {
   return (


### PR DESCRIPTION
## Summary
- replace period dropdown with new `PeriodSelector` button group
- add sticky mobile styles for the selector
- keep charts and "Reduce Others" sections tied to filtered transactions

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689863d094b8832eaded1cd682c67911