### PR TITLE
Add sticky app bar with overflow actions

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,69 @@
+ :root {
+  --app-bar-height: 56px;
+}
+
+.app-bar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: var(--app-bar-height);
+  background: #fff;
+  border-bottom: 1px solid #eaecef;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 16px;
+  z-index: 40;
+}
+
+.app-bar-title {
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.app-bar-actions {
+  position: relative;
+}
+
+.menu-btn {
+  background: transparent;
+  border: none;
+  font-size: 24px;
+  cursor: pointer;
+}
+
+.overflow-menu {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 8px);
+  background: #fff;
+  border: 1px solid #eaecef;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  padding: 8px 0;
+  width: 160px;
+  z-index: 50;
+}
+
+.overflow-menu button {
+  display: block;
+  width: 100%;
+  padding: 8px 16px;
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+}
+
+.overflow-menu button:hover {
+  background: #f3f4f6;
+}
+
+.container.app-content {
+  padding-top: calc(24px + var(--app-bar-height));
+}
+
 .container {
   max-width: 1100px;
   margin: 0 auto;


### PR DESCRIPTION
## Summary
- introduce sticky top app bar with title and overflow actions for CSV upload, recalculation, and logout
- add CSS for fixed app bar and padding so content doesn't overlap

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689869ac4d88832e9d942aa198e1d405