### PR TITLE
Add PWA install prompt and iOS hint

### DIFF
--- a/assets/pwa-install.js
+++ b/assets/pwa-install.js
@@ -1,0 +1,29 @@
+let deferredPrompt;
+const installBtn = document.getElementById('pwaInstallBtn');
+const iosHint   = document.getElementById('iosHint');
+
+const isStandalone = () =>
+  window.matchMedia('(display-mode: standalone)').matches ||
+  window.navigator.standalone === true;
+
+const isIOS = () => /iPhone|iPad|iPod/.test(window.navigator.userAgent);
+
+if (!localStorage.getItem('pwa_installed') && !isStandalone()) {
+  window.addEventListener('beforeinstallprompt', (e) => {
+    e.preventDefault();
+    deferredPrompt = e;
+    installBtn.hidden = false;
+  });
+
+  installBtn.addEventListener('click', async () => {
+    deferredPrompt?.prompt();
+    const { outcome } = await deferredPrompt.userChoice;
+    if (outcome === 'accepted') {
+      installBtn.hidden = true;
+      localStorage.setItem('pwa_installed', '1');
+    }
+    deferredPrompt = null;
+  });
+
+  if (isIOS() && !isStandalone()) iosHint.hidden = false;
+}

--- a/index.html
+++ b/index.html
@@ -8,5 +8,8 @@
   <body class="bg-gray-50">
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
+    <button id="pwaInstallBtn" hidden>ホーム画面に追加</button>
+    <div id="iosHint" hidden>Safariの共有 →「ホーム画面に追加」でアプリ化できます</div>
+    <script src="/assets/pwa-install.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add PWA install button, iOS install hint, and installer script reference to index.html
- implement PWA installation logic and iOS standalone hint in `assets/pwa-install.js`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689951f1b998832eb09c257678ef0d0c