### PR TITLE
refactor: split page components for lazy loading

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,12 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, lazy, Suspense } from 'react';
 import './App.css';
+
+const Monthly = lazy(() => import('./pages/Monthly.jsx'));
+const Yearly = lazy(() => import('./pages/Yearly.jsx'));
+const ImportCsv = lazy(() => import('./pages/ImportCsv.jsx'));
+const Rules = lazy(() => import('./pages/Rules.jsx'));
+const Transactions = lazy(() => import('./pages/Transactions.jsx'));
+const Prefs = lazy(() => import('./pages/Prefs.jsx'));
 
 const NAV = {
   main: [
@@ -93,12 +100,28 @@ export default function App() {
             onToggleOthers={() => setHideOthers(v => !v)}
           />
         )}
-        {page === 'monthly' && <Monthly />}
-        {page === 'yearly' && <Yearly />}
-        {page === 'import' && <ImportCsv />}
-        {page === 'rules' && <Rules />}
-        {page === 'tx' && <Transactions />}
-        {page === 'prefs' && <Prefs />}
+        <Suspense fallback={<div>Loading...</div>}>
+          {page === 'monthly' && (
+            <Monthly
+              period={period}
+              yenUnit={yenUnit}
+              lockColors={lockColors}
+              hideOthers={hideOthers}
+            />
+          )}
+          {page === 'yearly' && (
+            <Yearly
+              period={period}
+              yenUnit={yenUnit}
+              lockColors={lockColors}
+              hideOthers={hideOthers}
+            />
+          )}
+          {page === 'import' && <ImportCsv />}
+          {page === 'rules' && <Rules />}
+          {page === 'tx' && <Transactions />}
+          {page === 'prefs' && <Prefs />}
+        </Suspense>
       </main>
 
       {/* 最小限のスタイル（既存CSSに合わせて調整可） */}
@@ -150,12 +173,6 @@ function Dashboard({ period, yenUnit, lockColors, hideOthers, onToggleUnit, onTo
     </section>
   );
 }
-function Monthly(){ return <section><h2>月次比較</h2><div className='card'>（棒/折れ線 既存グラフ）</div></section>; }
-function Yearly(){ return <section><h2>年間サマリ</h2><div className='card'>（円/ツリー 既存グラフ）</div></section>; }
-function ImportCsv(){ return <section><h2>CSV取込</h2><div className='card'>（既存のアップローダ）</div></section>; }
-function Rules(){ return <section><h2>再分類ルール</h2><div className='card'>（既存のルール表）</div></section>; }
-function Transactions(){ return <section><h2>取引一覧</h2><div className='card'>（検索・絞り込み）</div></section>; }
-function Prefs(){ return <section><h2>設定</h2><div className='card'>（表示設定ほか）</div></section>; }
 
 function BarChart() {
   return (

--- a/src/pages/ImportCsv.jsx
+++ b/src/pages/ImportCsv.jsx
@@ -1,0 +1,8 @@
+export default function ImportCsv() {
+  return (
+    <section>
+      <h2>CSV取込</h2>
+      <div className='card'>（既存のアップローダ）</div>
+    </section>
+  );
+}

--- a/src/pages/Monthly.jsx
+++ b/src/pages/Monthly.jsx
@@ -1,0 +1,8 @@
+export default function Monthly({ period, yenUnit, lockColors, hideOthers }) {
+  return (
+    <section>
+      <h2>月次比較</h2>
+      <div className='card'>（棒/折れ線 既存グラフ）</div>
+    </section>
+  );
+}

--- a/src/pages/Prefs.jsx
+++ b/src/pages/Prefs.jsx
@@ -1,0 +1,8 @@
+export default function Prefs() {
+  return (
+    <section>
+      <h2>設定</h2>
+      <div className='card'>（表示設定ほか）</div>
+    </section>
+  );
+}

--- a/src/pages/Rules.jsx
+++ b/src/pages/Rules.jsx
@@ -1,0 +1,8 @@
+export default function Rules() {
+  return (
+    <section>
+      <h2>再分類ルール</h2>
+      <div className='card'>（既存のルール表）</div>
+    </section>
+  );
+}

--- a/src/pages/Transactions.jsx
+++ b/src/pages/Transactions.jsx
@@ -1,0 +1,8 @@
+export default function Transactions() {
+  return (
+    <section>
+      <h2>取引一覧</h2>
+      <div className='card'>（検索・絞り込み）</div>
+    </section>
+  );
+}

--- a/src/pages/Yearly.jsx
+++ b/src/pages/Yearly.jsx
@@ -1,0 +1,8 @@
+export default function Yearly({ period, yenUnit, lockColors, hideOthers }) {
+  return (
+    <section>
+      <h2>年間サマリ</h2>
+      <div className='card'>（円/ツリー 既存グラフ）</div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- extract Monthly, Yearly, ImportCsv, Rules, Transactions and Prefs into `src/pages`
- load page components lazily using `React.lazy` and `Suspense`
- wrap non-dashboard pages in a `Suspense` boundary

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689999077bb0832eb79897c24a400f5d