### PR TITLE
Render charts on monthly and yearly pages

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -336,7 +336,7 @@ function Dashboard({ period, yenUnit, lockColors, hideOthers, onToggleUnit, onTo
   );
 }
 
-function BarChart({ period, yenUnit, lockColors, hideOthers }) {
+export function BarChart({ period, yenUnit, lockColors, hideOthers }) {
   const limitMap = { '3m': 3, '6m': 6, '1y': 12, all: SAMPLE_DATA.length };
   const limit = limitMap[period] || SAMPLE_DATA.length;
   const raw = SAMPLE_DATA.slice(-limit);
@@ -401,7 +401,7 @@ function BarChart({ period, yenUnit, lockColors, hideOthers }) {
   );
 }
 
-function PieChart({ period, yenUnit, lockColors, hideOthers }) {
+export function PieChart({ period, yenUnit, lockColors, hideOthers }) {
   const limitMap = { '3m': 3, '6m': 6, '1y': 12, all: SAMPLE_DATA.length };
   const limit = limitMap[period] || SAMPLE_DATA.length;
   const raw = SAMPLE_DATA.slice(-limit);

--- a/src/pages/Monthly.jsx
+++ b/src/pages/Monthly.jsx
@@ -1,8 +1,17 @@
+import { BarChart } from '../App.jsx';
+
 export default function Monthly({ period, yenUnit, lockColors, hideOthers }) {
   return (
     <section>
       <h2>月次比較</h2>
-      <div className='card'>（棒/折れ線 既存グラフ）</div>
+      <div className='card'>
+        <BarChart
+          period={period}
+          yenUnit={yenUnit}
+          lockColors={lockColors}
+          hideOthers={hideOthers}
+        />
+      </div>
     </section>
   );
 }

--- a/src/pages/Yearly.jsx
+++ b/src/pages/Yearly.jsx
@@ -1,8 +1,17 @@
+import { PieChart as CategoryPieChart } from '../App.jsx';
+
 export default function Yearly({ period, yenUnit, lockColors, hideOthers }) {
   return (
     <section>
       <h2>年間サマリ</h2>
-      <div className='card'>（円/ツリー 既存グラフ）</div>
+      <div className='card'>
+        <CategoryPieChart
+          period={period}
+          yenUnit={yenUnit}
+          lockColors={lockColors}
+          hideOthers={hideOthers}
+        />
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- Replace placeholder content on Monthly and Yearly pages with shared Recharts components
- Export BarChart and PieChart from App for reuse across routes
- Wire period, unit, color-lock and hide-others toggles through to these pages

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899a31f30d0832e862174e44fa003c9