### PR TITLE
Use real BarChart in Monthly page and remove placeholder heading

### DIFF
--- a/src/pages/Monthly.jsx
+++ b/src/pages/Monthly.jsx
@@ -3,7 +3,6 @@ import { BarChart } from '../App.jsx';
 export default function Monthly({ period, yenUnit, lockColors, hideOthers }) {
   return (
     <section>
-      <h2>月次比較</h2>
       <div className='card'>
         <BarChart
           period={period}


### PR DESCRIPTION
## Summary
- Remove placeholder heading from Monthly page
- Ensure Monthly component forwards period, yenUnit, lockColors, hideOthers to BarChart

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6899a669d4bc832e964fdb38bd1d15be