### PR TITLE
Use finalized PieChart in Yearly page

### DIFF
--- a/src/pages/Yearly.jsx
+++ b/src/pages/Yearly.jsx
@@ -1,11 +1,10 @@
-import { PieChart as CategoryPieChart } from '../App.jsx';
+import { PieChart } from '../App.jsx';
 
 export default function Yearly({ period, yenUnit, lockColors, hideOthers }) {
   return (
     <section>
-      <h2>年間サマリ</h2>
       <div className='card'>
-        <CategoryPieChart
+        <PieChart
           period={period}
           yenUnit={yenUnit}
           lockColors={lockColors}


### PR DESCRIPTION
## Summary
- import finalized PieChart component into Yearly page
- pass period, yenUnit, lockColors, and hideOthers directly to PieChart
- clean up placeholder heading

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6899a7a1ace8832ea58f2f7490b50406