### PR TITLE
feat: add global store context

### DIFF
--- a/src/state/StoreContext.js
+++ b/src/state/StoreContext.js
@@ -1,0 +1,111 @@
+import { createContext, useContext, useReducer, useEffect } from 'react';
+
+const initialState = {
+  transactions: [],
+  rules: [],
+  lastImportAt: null,
+};
+
+function applyRulesToTransactions(transactions, rules) {
+  return transactions.map(tx => {
+    const matched = rules.find(rule => {
+      try {
+        const pattern = rule.pattern || rule.regex || rule.keyword;
+        if (!pattern) return false;
+        const reg = rule.regex
+          ? new RegExp(rule.regex, rule.flags || 'i')
+          : new RegExp(pattern, 'i');
+        const target = tx.description || tx.detail || tx.memo || '';
+        return reg.test(target);
+      } catch {
+        return false;
+      }
+    });
+    return matched ? { ...tx, category: matched.category } : tx;
+  });
+}
+
+function reducer(state, action) {
+  switch (action.type) {
+    case 'loadFromStorage': {
+      let transactions = [];
+      let lastImportAt = null;
+      const txRaw = localStorage.getItem('lm_tx_v1');
+      if (txRaw) {
+        try {
+          const parsed = JSON.parse(txRaw);
+          if (Array.isArray(parsed)) {
+            transactions = parsed;
+          } else {
+            transactions = parsed.transactions || [];
+            lastImportAt = parsed.lastImportAt || null;
+          }
+        } catch {
+          // ignore
+        }
+      }
+      let rules = [];
+      const ruleRaw = localStorage.getItem('lm_rules_v1');
+      if (ruleRaw) {
+        try {
+          rules = JSON.parse(ruleRaw) || [];
+        } catch {
+          // ignore
+        }
+      }
+      return { transactions, rules, lastImportAt };
+    }
+    case 'importTransactions': {
+      const newTx = state.transactions.concat(action.payload || []);
+      const lastImportAt = new Date().toISOString();
+      localStorage.setItem(
+        'lm_tx_v1',
+        JSON.stringify({ transactions: newTx, lastImportAt })
+      );
+      return { ...state, transactions: newTx, lastImportAt };
+    }
+    case 'setRules': {
+      const rules = action.payload || [];
+      localStorage.setItem('lm_rules_v1', JSON.stringify(rules));
+      return { ...state, rules };
+    }
+    case 'applyRules': {
+      const transactions = applyRulesToTransactions(state.transactions, state.rules);
+      localStorage.setItem(
+        'lm_tx_v1',
+        JSON.stringify({ transactions, lastImportAt: state.lastImportAt })
+      );
+      return { ...state, transactions };
+    }
+    case 'clearAll': {
+      localStorage.removeItem('lm_tx_v1');
+      localStorage.removeItem('lm_rules_v1');
+      return initialState;
+    }
+    default:
+      return state;
+  }
+}
+
+const StoreContext = createContext();
+
+export function StoreProvider({ children }) {
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  useEffect(() => {
+    dispatch({ type: 'loadFromStorage' });
+  }, []);
+
+  return (
+    <StoreContext.Provider value={{ state, dispatch }}>
+      {children}
+    </StoreContext.Provider>
+  );
+}
+
+export function useStore() {
+  const ctx = useContext(StoreContext);
+  if (!ctx) throw new Error('useStore must be used within StoreProvider');
+  return ctx;
+}
+


### PR DESCRIPTION
## Summary
- implement global store with React context and reducer
- persist transactions and rules to localStorage

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6899ade3a848832e853b051a4a489a48