### PR TITLE
Add shared ledger types and integrate with store context

### DIFF
--- a/src/pages/Rules.jsx
+++ b/src/pages/Rules.jsx
@@ -1,8 +1,14 @@
+import { useStore } from '../state/StoreContext';
+/** @typedef {import('../types').Rule} Rule */
+
 export default function Rules() {
+  const { state } = useStore();
+  /** @type {Rule[]} */
+  const rules = state.rules;
   return (
     <section>
       <h2>再分類ルール</h2>
-      <div className='card'>（既存のルール表）</div>
+      <div className='card'>（{rules.length}件のルール）</div>
     </section>
   );
 }

--- a/src/pages/Transactions.jsx
+++ b/src/pages/Transactions.jsx
@@ -1,8 +1,14 @@
+import { useStore } from '../state/StoreContext';
+/** @typedef {import('../types').Transaction} Transaction */
+
 export default function Transactions() {
+  const { state } = useStore();
+  /** @type {Transaction[]} */
+  const txs = state.transactions;
   return (
     <section>
       <h2>取引一覧</h2>
-      <div className='card'>（検索・絞り込み）</div>
+      <div className='card'>（{txs.length} 件の取引）</div>
     </section>
   );
 }

--- a/src/state/StoreContext.jsx
+++ b/src/state/StoreContext.jsx
@@ -1,11 +1,21 @@
 import { createContext, useContext, useReducer, useEffect } from 'react';
+/** @typedef {import('../types').Transaction} Transaction */
+/** @typedef {import('../types').Rule} Rule */
+/** @typedef {import('../types').StoreState} StoreState */
+/** @typedef {import('../types').StoreAction} StoreAction */
 
+/** @type {StoreState} */
 const initialState = {
   transactions: [],
   rules: [],
   lastImportAt: null,
 };
 
+/**
+ * @param {Transaction[]} transactions
+ * @param {Rule[]} rules
+ * @returns {Transaction[]}
+ */
 function applyRulesToTransactions(transactions, rules) {
   return transactions.map(tx => {
     const matched = rules.find(rule => {
@@ -25,6 +35,11 @@ function applyRulesToTransactions(transactions, rules) {
   });
 }
 
+/**
+ * @param {StoreState} state
+ * @param {StoreAction} action
+ * @returns {StoreState}
+ */
 function reducer(state, action) {
   switch (action.type) {
     case 'loadFromStorage': {
@@ -87,8 +102,17 @@ function reducer(state, action) {
   }
 }
 
+/**
+ * @type {import('react').Context<{
+ *   state: StoreState;
+ *   dispatch: import('react').Dispatch<StoreAction>;
+ * } | undefined>}
+ */
 const StoreContext = createContext();
 
+/**
+ * @param {{children: import('react').ReactNode}} props
+ */
 export function StoreProvider({ children }) {
   const [state, dispatch] = useReducer(reducer, initialState);
 
@@ -103,6 +127,9 @@ export function StoreProvider({ children }) {
   );
 }
 
+/**
+ * @returns {{state: StoreState, dispatch: import('react').Dispatch<StoreAction>}}
+ */
 export function useStore() {
   const ctx = useContext(StoreContext);
   if (!ctx) throw new Error('useStore must be used within StoreProvider');

--- a/src/types.js
+++ b/src/types.js
@@ -1,0 +1,57 @@
+/**
+ * @typedef {Object} Transaction
+ * @property {string} date - ISO 8601 date string of the transaction.
+ * @property {string} [description] - Short description of the transaction.
+ * @property {string} [detail] - Additional details such as payee or store name.
+ * @property {string} [memo] - Optional memo or note.
+ * @property {number} amount - Amount of the transaction. Negative for expenses.
+ * @property {string} [category] - Category assigned to the transaction.
+ */
+
+/**
+ * @typedef {Object} Rule
+ * @property {string} [pattern] - Simple pattern string to search in descriptions.
+ * @property {string} [regex] - Regular expression string for advanced matching.
+ * @property {string} [flags] - Flags for the regular expression.
+ * @property {string} [keyword] - Keyword used for matching when pattern/regex is absent.
+ * @property {string} category - Category to apply when rule matches.
+ */
+
+/**
+ * @typedef {Object} StoreState
+ * @property {Transaction[]} transactions - Imported transactions after applying rules.
+ * @property {Rule[]} rules - Reclassification rules defined by the user.
+ * @property {string|null} lastImportAt - ISO string for last import timestamp.
+ */
+
+/**
+ * @typedef {{ type: 'loadFromStorage' }} LoadFromStorageAction
+ */
+
+/**
+ * @typedef {{ type: 'importTransactions', payload?: Transaction[] }} ImportTransactionsAction
+ */
+
+/**
+ * @typedef {{ type: 'setRules', payload?: Rule[] }} SetRulesAction
+ */
+
+/**
+ * @typedef {{ type: 'applyRules' }} ApplyRulesAction
+ */
+
+/**
+ * @typedef {{ type: 'clearAll' }} ClearAllAction
+ */
+
+/**
+ * @typedef {(
+ *   | LoadFromStorageAction
+ *   | ImportTransactionsAction
+ *   | SetRulesAction
+ *   | ApplyRulesAction
+ *   | ClearAllAction
+ * )} StoreAction
+ */
+
+export {};


### PR DESCRIPTION
## Summary
- define Transaction, Rule, StoreState and StoreAction in a shared `types.js`
- annotate StoreContext with these types for state, reducer and actions
- expose state types to Rules and Transactions pages via `useStore`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899aeef51cc832eb7ca0a1c0b44857a