### PR TITLE
Wrap app with StoreProvider

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, lazy, Suspense, useRef, useMemo } from 'react';
 import './App.css';
+import { useStore } from './state/StoreContext.jsx';
 import {
   ResponsiveContainer,
   BarChart as ReBarChart,
@@ -89,6 +90,7 @@ function serializeHash({
 }
 
 export default function App() {
+  const { state, dispatch } = useStore();
   const getInitial = () => {
     const h = parseHash(window.location.hash || '');
     const stored = {
@@ -131,6 +133,10 @@ export default function App() {
   const [hideOthers, setHideOthers] = useState(init.hideOthers);
   const burgerRef = useRef(null);
   const panelRef = useRef(null);
+
+  useEffect(() => {
+    dispatch({ type: 'applyRules' });
+  }, [state.rules, state.transactions, dispatch]);
 
   useEffect(() => {
     const onHash = () => {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,5 +2,10 @@ import React from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App.jsx";
+import { StoreProvider } from "./state/StoreContext.jsx";
 
-createRoot(document.getElementById("root")).render(<App />);
+createRoot(document.getElementById("root")).render(
+  <StoreProvider>
+    <App />
+  </StoreProvider>
+);


### PR DESCRIPTION
## Summary
- Import `StoreProvider` and wrap app rendering so global state is available
- Expose store in `App` and apply rules whenever transactions or rules change

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899b0163640832ebdb02795f8848e27