### PR TITLE
Add append option for transaction imports

### DIFF
--- a/src/pages/ImportCsv.jsx
+++ b/src/pages/ImportCsv.jsx
@@ -1,8 +1,35 @@
+import { useState } from 'react';
+import { useStore } from '../state/StoreContext';
+import { parseCsvFiles } from '../utils/csv.js';
+
 export default function ImportCsv() {
+  const { dispatch } = useStore();
+  const [append, setAppend] = useState(true);
+
+  async function handleChange(e) {
+    const files = e.target.files;
+    if (!files || files.length === 0) return;
+    const txs = await parseCsvFiles(files);
+    dispatch({ type: 'importTransactions', payload: txs, append });
+    e.target.value = '';
+  }
+
   return (
     <section>
       <h2>CSV取込</h2>
-      <div className='card'>（既存のアップローダ）</div>
+      <div className='card'>
+        <div className='space-y-2'>
+          <input type='file' multiple onChange={handleChange} />
+          <label className='block'>
+            <input
+              type='checkbox'
+              checked={append}
+              onChange={(e) => setAppend(e.target.checked)}
+            />
+            <span className='ml-2'>既存の取引に追加する</span>
+          </label>
+        </div>
+      </div>
     </section>
   );
 }

--- a/src/state/StoreContext.jsx
+++ b/src/state/StoreContext.jsx
@@ -71,7 +71,10 @@ function reducer(state, action) {
       return { transactions, rules, lastImportAt };
     }
     case 'importTransactions': {
-      const newTx = state.transactions.concat(action.payload || []);
+      const append = action.append !== false;
+      const newTx = append
+        ? state.transactions.concat(action.payload || [])
+        : action.payload || [];
       const lastImportAt = new Date().toISOString();
       localStorage.setItem(
         'lm_tx_v1',

--- a/src/types.js
+++ b/src/types.js
@@ -29,7 +29,11 @@
  */
 
 /**
- * @typedef {{ type: 'importTransactions', payload?: Transaction[] }} ImportTransactionsAction
+ * @typedef {{
+ *   type: 'importTransactions';
+ *   payload?: Transaction[];
+ *   append?: boolean;
+ * }} ImportTransactionsAction
  */
 
 /**


### PR DESCRIPTION
## Summary
- support optional `append` flag when importing transactions
- handle append or replace logic in reducer and localStorage persistence
- expose append option in CSV import UI

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899b4b77160832eaed6fc6331192a6b