### PR TITLE
Use real transaction data for dashboard charts

### DIFF
--- a/src/BarByMonth.jsx
+++ b/src/BarByMonth.jsx
@@ -1,0 +1,144 @@
+import { useRef, useMemo } from 'react';
+import {
+  ResponsiveContainer,
+  BarChart as ReBarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  Cell,
+} from 'recharts';
+
+const BAR_COLORS = [
+  '#60a5fa',
+  '#34d399',
+  '#fbbf24',
+  '#f87171',
+  '#a78bfa',
+  '#fb923c',
+];
+
+function ScrollableLegend({ payload }) {
+  const isMobile = typeof window !== 'undefined' && window.innerWidth < 640;
+  return (
+    <ul
+      style={{
+        listStyle: 'none',
+        margin: 0,
+        padding: 0,
+        display: 'flex',
+        flexDirection: isMobile ? 'column' : 'row',
+        flexWrap: isMobile ? 'nowrap' : 'wrap',
+        maxHeight: isMobile ? 72 : undefined,
+        overflowY: isMobile ? 'auto' : undefined,
+      }}
+    >
+      {payload?.map((entry) => {
+        const label = entry.value || '';
+        const truncated = label.length > 8 ? `${label.slice(0, 8)}…` : label;
+        return (
+          <li
+            key={label}
+            title={`${label} ${entry.formatted ?? ''}`}
+            style={{ marginRight: 12, display: 'flex', alignItems: 'center' }}
+          >
+            <span
+              style={{
+                display: 'inline-block',
+                width: 10,
+                height: 10,
+                backgroundColor: entry.color,
+                marginRight: 4,
+              }}
+            />
+            <span>{truncated}</span>
+            {entry.formatted && (
+              <span style={{ marginLeft: 4, color: 'var(--muted)' }}>
+                {entry.formatted}
+              </span>
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+export default function BarByMonth({
+  transactions,
+  period,
+  yenUnit,
+  lockColors,
+  hideOthers,
+}) {
+  const monthMap = {};
+  transactions
+    .filter((tx) => tx.amount < 0)
+    .forEach((tx) => {
+      if (hideOthers && tx.category === 'その他') return;
+      const month = tx.date.slice(0, 7);
+      monthMap[month] = (monthMap[month] || 0) + Math.abs(tx.amount);
+    });
+  const months = Object.keys(monthMap).sort();
+  const limitMap = { '3m': 3, '6m': 6, '1y': 12, all: months.length };
+  const limit = limitMap[period] || months.length;
+  const data = months
+    .slice(-limit)
+    .map((m) => ({ month: m, total: monthMap[m] }));
+
+  const colorMap = useRef({});
+  const dataWithColors = useMemo(() => {
+    if (!lockColors) colorMap.current = {};
+    data.forEach((d) => {
+      if (!colorMap.current[d.month]) {
+        const used = Object.keys(colorMap.current).length;
+        colorMap.current[d.month] = BAR_COLORS[used % BAR_COLORS.length];
+      }
+    });
+    return data.map((d) => ({ ...d, fill: colorMap.current[d.month] }));
+  }, [data, lockColors]);
+
+  const tickFormatter = (v) => (yenUnit === 'man' ? (v / 10000).toFixed(1) : v);
+  const formatValue = (v) =>
+    yenUnit === 'man' ? `${(v / 10000).toFixed(1)} 万円` : `${v} 円`;
+  const tooltipFormatter = (v) => [formatValue(v), '合計'];
+  const legendPayload = dataWithColors.map((d) => ({
+    id: d.month,
+    value: d.month,
+    formatted: formatValue(d.total),
+    type: 'square',
+    color: d.fill,
+  }));
+
+  return (
+    <ResponsiveContainer width="100%" height={200}>
+      <ReBarChart data={dataWithColors} margin={{ top: 8, right: 16, left: 0, bottom: 28 }}>
+        <XAxis
+          dataKey="month"
+          interval={0}
+          angle={-45}
+          textAnchor="end"
+          height={60}
+          tickFormatter={(v) => (v.length > 8 ? `${v.slice(0, 8)}…` : v)}
+        />
+        <YAxis
+          tickFormatter={tickFormatter}
+          label={{
+            value: yenUnit === 'man' ? '万円' : '円',
+            angle: -90,
+            position: 'insideLeft',
+          }}
+        />
+        <Tooltip formatter={tooltipFormatter} labelFormatter={(label) => label} />
+        <Legend content={<ScrollableLegend />} payload={legendPayload} />
+        <Bar dataKey="total" name="合計">
+          {dataWithColors.map((entry, idx) => (
+            <Cell key={`cell-${idx}`} fill={entry.fill} />
+          ))}
+        </Bar>
+      </ReBarChart>
+    </ResponsiveContainer>
+  );
+}
+

--- a/src/PieByCategory.jsx
+++ b/src/PieByCategory.jsx
@@ -1,0 +1,101 @@
+import { useRef, useMemo } from 'react';
+import {
+  ResponsiveContainer,
+  PieChart as RePieChart,
+  Pie,
+  Legend,
+  Tooltip,
+  Cell,
+} from 'recharts';
+
+const BAR_COLORS = [
+  '#60a5fa',
+  '#34d399',
+  '#fbbf24',
+  '#f87171',
+  '#a78bfa',
+  '#fb923c',
+];
+
+export default function PieByCategory({
+  transactions,
+  period,
+  yenUnit,
+  lockColors,
+  hideOthers,
+}) {
+  const monthMap = {};
+  const expenses = transactions.filter((tx) => tx.amount < 0);
+  expenses.forEach((tx) => {
+    const month = tx.date.slice(0, 7);
+    (monthMap[month] = monthMap[month] || []).push(tx);
+  });
+  const months = Object.keys(monthMap).sort();
+  const limitMap = { '3m': 3, '6m': 6, '1y': 12, all: months.length };
+  const limit = limitMap[period] || months.length;
+  const selectedMonths = months.slice(-limit);
+  const filteredTx = selectedMonths.flatMap((m) => monthMap[m] || []);
+
+  const totals = {};
+  filteredTx.forEach((tx) => {
+    const cat = tx.category || 'その他';
+    totals[cat] = (totals[cat] || 0) + Math.abs(tx.amount);
+  });
+  const totalSum = Object.values(totals).reduce((s, v) => s + v, 0);
+  const items = [];
+  let othersValue = 0;
+  Object.entries(totals).forEach(([name, value]) => {
+    const ratio = totalSum ? value / totalSum : 0;
+    if (name === 'その他' || ratio < 0.03) {
+      othersValue += value;
+    } else {
+      items.push({ name, value });
+    }
+  });
+  if (!hideOthers && othersValue > 0) {
+    items.push({ name: 'その他', value: othersValue });
+  }
+
+  const colorMap = useRef({});
+  const dataWithColors = useMemo(() => {
+    if (!lockColors) colorMap.current = {};
+    items.forEach((d) => {
+      if (!colorMap.current[d.name]) {
+        const used = Object.keys(colorMap.current).length;
+        colorMap.current[d.name] = BAR_COLORS[used % BAR_COLORS.length];
+      }
+    });
+    return items.map((d) => ({ ...d, fill: colorMap.current[d.name] }));
+  }, [items, lockColors]);
+
+  const formatValue = (v) =>
+    yenUnit === 'man' ? `${(v / 10000).toFixed(1)} 万円` : `${v} 円`;
+  const tooltipFormatter = (v, name) => [formatValue(v), name];
+  const legendPayload = dataWithColors.map((item) => ({
+    id: item.name,
+    type: 'square',
+    color: item.fill,
+    value: `${item.name}: ${formatValue(item.value)}`,
+  }));
+
+  return (
+    <ResponsiveContainer width="100%" height={200}>
+      <RePieChart>
+        <Pie data={dataWithColors} dataKey="value" nameKey="name" label outerRadius="80%">
+          {dataWithColors.map((entry, index) => (
+            <Cell key={`cell-${index}`} fill={entry.fill} />
+          ))}
+        </Pie>
+        <Legend
+          layout="vertical"
+          align="right"
+          verticalAlign="middle"
+          wrapperStyle={{ maxHeight: 300, overflowY: 'auto' }}
+          payload={legendPayload}
+        />
+        <Tooltip formatter={tooltipFormatter} />
+      </RePieChart>
+    </ResponsiveContainer>
+  );
+}
+

--- a/src/pages/Monthly.jsx
+++ b/src/pages/Monthly.jsx
@@ -1,10 +1,11 @@
-import { BarChart } from '../App.jsx';
+import BarByMonth from '../BarByMonth.jsx';
 
-export default function Monthly({ period, yenUnit, lockColors, hideOthers }) {
+export default function Monthly({ transactions, period, yenUnit, lockColors, hideOthers }) {
   return (
     <section>
       <div className='card'>
-        <BarChart
+        <BarByMonth
+          transactions={transactions}
           period={period}
           yenUnit={yenUnit}
           lockColors={lockColors}

--- a/src/pages/Yearly.jsx
+++ b/src/pages/Yearly.jsx
@@ -1,10 +1,11 @@
-import { PieChart } from '../App.jsx';
+import PieByCategory from '../PieByCategory.jsx';
 
-export default function Yearly({ period, yenUnit, lockColors, hideOthers }) {
+export default function Yearly({ transactions, period, yenUnit, lockColors, hideOthers }) {
   return (
     <section>
       <div className='card'>
-        <PieChart
+        <PieByCategory
+          transactions={transactions}
           period={period}
           yenUnit={yenUnit}
           lockColors={lockColors}


### PR DESCRIPTION
## Summary
- Replace SAMPLE_DATA with live transactions and wire dashboard/monthly/yearly views to store
- Add `BarByMonth` and `PieByCategory` components for monthly totals and category ratios
- Support hiding "その他" and color locking across charts

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899bbfe3c34832eb1ac86855f25a97f