### PR TITLE
feat: support rule matching modes

### DIFF
--- a/src/types.js
+++ b/src/types.js
@@ -14,6 +14,9 @@
  * @property {string} [regex] - Regular expression string for advanced matching.
  * @property {string} [flags] - Flags for the regular expression.
  * @property {string} [keyword] - Keyword used for matching when pattern/regex is absent.
+ * @property {'contains'|'regex'} [mode] - Matching mode: substring or regular expression.
+ * @property {'description'|'detail'|'memo'} [target] - Transaction field to evaluate.
+ * @property {'expense'|'income'|'both'} [kind] - Transaction kind this rule applies to.
  * @property {string} category - Category to apply when rule matches.
  */
 


### PR DESCRIPTION
## Summary
- add `mode`, `target`, and `kind` fields to reclassification rules
- apply rules using mode/target/kind and run them when importing transactions or updating rules

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6899cf2bac18832ebe27f88e36e883de