### PR TITLE
feat: apply rules after CSV import

### DIFF
--- a/src/pages/ImportCsv.jsx
+++ b/src/pages/ImportCsv.jsx
@@ -24,6 +24,7 @@ export default function ImportCsv() {
     setPreview([]);
     setHeaderMap({});
     setErrors([]);
+    dispatch({ type: 'applyRules' });
   }
 
   const KNOWN_FIELDS = ['date', 'description', 'detail', 'memo', 'amount', 'category'];


### PR DESCRIPTION
## Summary
- reapply classification rules right after importing transactions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6899d3887ed0832eb21ae49d0d6660b7