### PR TITLE
Add page to categorize 'others' transactions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ const Yearly = lazy(() => import('./pages/Yearly.jsx'));
 const ImportCsv = lazy(() => import('./pages/ImportCsv.jsx'));
 const Rules = lazy(() => import('./pages/Rules.jsx'));
 const Transactions = lazy(() => import('./pages/Transactions.jsx'));
+const Others = lazy(() => import('./pages/Others.jsx'));
 const Prefs = lazy(() => import('./pages/Prefs.jsx'));
 
 const NAV = {
@@ -20,6 +21,7 @@ const NAV = {
   data: [
     { key: 'import', label: 'CSV取込' },
     { key: 'rules', label: '再分類ルール' },
+    { key: 'others', label: 'その他集計' },
     { key: 'tx', label: '取引一覧' },
   ],
   settings: [{ key: 'prefs', label: '設定' }],
@@ -258,6 +260,7 @@ export default function App() {
           )}
           {page === 'import' && <ImportCsv />}
           {page === 'rules' && <Rules />}
+          {page === 'others' && <Others />}
           {page === 'tx' && <Transactions />}
           {page === 'prefs' && <Prefs />}
         </Suspense>

--- a/src/OthersTable.jsx
+++ b/src/OthersTable.jsx
@@ -60,6 +60,16 @@ function OthersRow({ row, onAdd, isMobile }) {
   );
 }
 
+/**
+ * @param {{
+ *   rows: { name: string; total: number }[];
+ *   addRule: (rule: import('./types').Rule) => void;
+ *   isMobile: boolean;
+ * }} props
+ * `addRule` は新しいルールを上位コンポーネントで保存するためのコールバック。
+ * 利用側では `dispatch({ type: 'setRules', payload: [...rules, newRule] })`
+ * および `dispatch({ type: 'applyRules' })` を実行する想定。
+ */
 export default function OthersTable({ rows, addRule, isMobile }) {
   return (
     <table style={{ width: '100%', borderCollapse: 'collapse' }}>

--- a/src/pages/Others.jsx
+++ b/src/pages/Others.jsx
@@ -1,0 +1,35 @@
+import { useMemo } from 'react';
+import OthersTable from '../OthersTable.jsx';
+import { useStore } from '../state/StoreContext.jsx';
+
+export default function Others() {
+  const { state, dispatch } = useStore();
+  const rows = useMemo(() => {
+    const map = {};
+    state.transactions
+      .filter(tx => tx.category === 'その他' && tx.amount < 0)
+      .forEach(tx => {
+        if (!tx.memo) return;
+        map[tx.memo] = (map[tx.memo] || 0) + Math.abs(tx.amount);
+      });
+    return Object.entries(map)
+      .map(([name, total]) => ({ name, total }))
+      .sort((a, b) => b.total - a.total);
+  }, [state.transactions]);
+
+  const addRule = newRule => {
+    dispatch({ type: 'setRules', payload: [...state.rules, newRule] });
+    dispatch({ type: 'applyRules' });
+  };
+
+  const isMobile = typeof window !== 'undefined' && window.innerWidth < 640;
+
+  return (
+    <section>
+      <h2>その他の内訳</h2>
+      <div className="card">
+        <OthersTable rows={rows} addRule={addRule} isMobile={isMobile} />
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- clarify addRule usage with dispatch steps in OthersTable
- introduce Others page to aggregate uncategorized entries and add rules
- wire navigation and routing for the new page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899d7d62f60832ea9b6a2ef82fa396a