### PR TITLE
Add Supabase env example and setup instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+VITE_SUPABASE_URL=https://example.supabase.co
+VITE_SUPABASE_ANON_KEY=example-anon-key

--- a/README-ja.md
+++ b/README-ja.md
@@ -3,6 +3,8 @@
 ## セットアップ
 ```bash
 npm install
+cp .env.example .env
+# .env を編集して Supabase の URL と anon key を設定
 npm run dev
 ```
 - ブラウザで http://localhost:5173 を開きます。


### PR DESCRIPTION
## Summary
- add `.env.example` with dummy Supabase credentials
- document `.env` creation and Supabase URL/key setup in README-ja

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689acbd551f8832eabfeeb855c337a79