### PR TITLE
Validate Supabase env vars before client initialization

### DIFF
--- a/src/supabaseClient.js
+++ b/src/supabaseClient.js
@@ -1,6 +1,22 @@
 import { createClient } from '@supabase/supabase-js';
 
-export const supabase = createClient(
-  import.meta.env.VITE_SUPABASE_URL,       // ← 変数名
-  import.meta.env.VITE_SUPABASE_ANON_KEY   // ← 変数名
-);
+// 環境変数を取得する。
+// Node.js でのテスト実行時は process.env を、Vite 環境では import.meta.env を利用する。
+const env = {
+  ...(typeof process !== 'undefined' ? process.env : {}),
+  ...(import.meta.env || {}),
+};
+
+const supabaseUrl = env.VITE_SUPABASE_URL;
+const supabaseAnonKey = env.VITE_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl || !supabaseAnonKey) {
+  const missing = [];
+  if (!supabaseUrl) missing.push('VITE_SUPABASE_URL');
+  if (!supabaseAnonKey) missing.push('VITE_SUPABASE_ANON_KEY');
+  const message = `Missing environment variable(s): ${missing.join(', ')}`;
+  console.error(message);
+  throw new Error(message);
+}
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);


### PR DESCRIPTION
## Summary
- ensure Supabase client throws a clear error when VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY are missing

## Testing
- `node -e "import('./src/supabaseClient.js').then(()=>console.log('loaded')).catch(err=>console.error('caught', err.message))"`
- `VITE_SUPABASE_URL='http://example.com' VITE_SUPABASE_ANON_KEY='anon-key' node -e "import('./src/supabaseClient.js').then(()=>console.log('loaded')).catch(err=>console.error('caught', err.message))"`
- `npm test` (fails: Missing script: "test")
- `VITE_SUPABASE_URL='http://example.com' VITE_SUPABASE_ANON_KEY='anon-key' npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689acce65bac832eba22ab40801a112a