### PR TITLE
Strip optional statement header from CSV parsing

### DIFF
--- a/src/utils/csv.js
+++ b/src/utils/csv.js
@@ -88,6 +88,13 @@ export async function parseCsvFiles(files) {
     const parsed = Papa.parse(text, {
       header: true,
       skipEmptyLines: true,
+      beforeFirstChunk(chunk) {
+        const lines = chunk.split(/\r?\n/);
+        if (lines[0].includes('月別ご利用明細')) {
+          return lines.slice(1).join('\n');
+        }
+        return chunk;
+      },
       transformHeader(header) {
         const canon = normalizeHeader(header);
         if (!(canon in headerMap)) headerMap[canon] = header.trim();


### PR DESCRIPTION
## Summary
- handle CSVs that start with `月別ご利用明細` by dropping the first line before parsing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ad16966dc832e86b764885f321cf0