### PR TITLE
Add shopping and cashing expense keywords in CSV parser

### DIFF
--- a/src/utils/csv.js
+++ b/src/utils/csv.js
@@ -62,9 +62,10 @@ function rowToTransaction(row) {
   if (Number.isNaN(amount)) return { tx: null, error: `Invalid amount: ${row.amount}` };
   if (row.kind) {
     const kind = String(row.kind).toLowerCase();
-    if (/(expense|支出|出金)/.test(kind)) {
+    if (/(expense|支出|出金|ショッピング|キャッシング)/.test(kind)) {
       amount = -Math.abs(amount);
     } else if (/(income|収入|入金)/.test(kind)) {
+      // TODO: Add more income type keywords if additional deposit kinds are introduced
       amount = Math.abs(amount);
     }
   }


### PR DESCRIPTION
## Summary
- support "ショッピング" and "キャッシング" as expense indicators when parsing CSV rows
- leave TODO for expanding income type detection for future deposit kinds

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ad3abd67c832eb02969d1c1521eff