### PR TITLE
feat: support bank-style csv headers

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -15,5 +15,11 @@ npm run dev
 - 可視化（Recharts）
 - Excel/CSV 出力（xlsx/papaparse）
 
+## CSVレイアウト
+- `年月日` ヘッダーや `YYYY/M/D` 形式の日付に対応
+- 金額列が無い場合は `お預入れ` / `お引出し` から金額を算出
+- 以下のヘッダー別名を自動認識します: `お取り扱い内容`→説明, `メモ`→メモ, `ラベル`→カテゴリ
+- 取り込みには `date` 列と `amount` または `お預入れ`/`お引出し` のいずれかが必要
+
 ## 依存
 - React 18, Vite 5, Tailwind CSS 3, Recharts 2, PapaParse 5, xlsx 0.18


### PR DESCRIPTION
## Summary
- support bank-style CSV fields like deposit/withdraw and header aliases
- parse Japanese dates in YYYY/M/D format
- compute amount from deposit/withdraw columns and relax mandatory column checks

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689ad795c540832e9b2beaffa679db7d