### PR TITLE
feat: track transaction kind separately from amount

### DIFF
--- a/src/BarByMonth.jsx
+++ b/src/BarByMonth.jsx
@@ -74,7 +74,7 @@ export default function BarByMonth({
 }) {
   const monthMap = {};
   transactions
-    .filter((tx) => tx.amount < 0)
+    .filter((tx) => tx.kind === 'expense')
     .forEach((tx) => {
       if (hideOthers && tx.category === 'その他') return;
       const month = tx.date.slice(0, 7);

--- a/src/PieByCategory.jsx
+++ b/src/PieByCategory.jsx
@@ -71,7 +71,7 @@ export default function PieByCategory({
   hideOthers,
 }) {
   const monthMap = {};
-  const expenses = transactions.filter((tx) => tx.amount < 0);
+  const expenses = transactions.filter((tx) => tx.kind === 'expense');
   expenses.forEach((tx) => {
     const month = tx.date.slice(0, 7);
     (monthMap[month] = monthMap[month] || []).push(tx);

--- a/src/pages/ImportCsv.jsx
+++ b/src/pages/ImportCsv.jsx
@@ -27,7 +27,15 @@ export default function ImportCsv() {
     e.target.value = '';
   }
 
-  const KNOWN_FIELDS = ['date', 'description', 'detail', 'memo', 'amount', 'category'];
+  const KNOWN_FIELDS = [
+    'date',
+    'description',
+    'detail',
+    'memo',
+    'amount',
+    'category',
+    'kind',
+  ];
 
   return (
     <section>

--- a/src/pages/Others.jsx
+++ b/src/pages/Others.jsx
@@ -7,7 +7,7 @@ export default function Others() {
   const rows = useMemo(() => {
     const map = {};
     state.transactions
-      .filter(tx => tx.category === 'その他' && tx.amount < 0)
+      .filter((tx) => tx.category === 'その他' && tx.kind === 'expense')
       .forEach(tx => {
         if (!tx.memo) return;
         map[tx.memo] = (map[tx.memo] || 0) + Math.abs(tx.amount);

--- a/src/pages/Transactions.jsx
+++ b/src/pages/Transactions.jsx
@@ -31,8 +31,8 @@ export default function Transactions() {
       const amt = Math.abs(tx.amount);
       if (minAmount !== '' && amt < Number(minAmount)) return false;
       if (maxAmount !== '' && amt > Number(maxAmount)) return false;
-      if (type === 'income' && tx.amount <= 0) return false;
-      if (type === 'expense' && tx.amount >= 0) return false;
+      if (type === 'income' && tx.kind !== 'income') return false;
+      if (type === 'expense' && tx.kind !== 'expense') return false;
       return true;
     });
   }, [txs, startDate, endDate, categories, keyword, minAmount, maxAmount, type]);

--- a/src/state/StoreContext.jsx
+++ b/src/state/StoreContext.jsx
@@ -22,7 +22,7 @@ function applyRulesToTransactions(transactions, rules) {
       try {
         const pattern = rule.pattern || rule.regex || rule.keyword;
         if (!pattern) return false;
-        const txKind = tx.amount < 0 ? 'expense' : 'income';
+        const txKind = tx.kind || (tx.amount < 0 ? 'expense' : 'income');
         const ruleKind = rule.kind || 'both';
         if (ruleKind !== 'both' && ruleKind !== txKind) return false;
         const target = rule.target
@@ -64,6 +64,10 @@ function reducer(state, action) {
             transactions = parsed.transactions || [];
             lastImportAt = parsed.lastImportAt || null;
           }
+          transactions = transactions.map(tx => ({
+            ...tx,
+            kind: tx.kind || (tx.amount < 0 ? 'expense' : 'income'),
+          }));
         } catch {
           // ignore
         }
@@ -84,7 +88,11 @@ function reducer(state, action) {
       const newTx = append
         ? state.transactions.concat(action.payload || [])
         : action.payload || [];
-      const transactions = applyRulesToTransactions(newTx, state.rules);
+      const newTxWithKind = newTx.map(tx => ({
+        ...tx,
+        kind: tx.kind || (tx.amount < 0 ? 'expense' : 'income'),
+      }));
+      const transactions = applyRulesToTransactions(newTxWithKind, state.rules);
       const lastImportAt = new Date().toISOString();
       localStorage.setItem(
         'lm_tx_v1',

--- a/src/types.js
+++ b/src/types.js
@@ -5,6 +5,7 @@
  * @property {string} [detail] - Additional details such as payee or store name.
  * @property {string} [memo] - Optional memo or note.
  * @property {number} amount - Amount of the transaction. Negative for expenses.
+ * @property {'income'|'expense'} kind - Transaction kind.
  * @property {string} [category] - Category assigned to the transaction.
  */
 

--- a/src/utils/csv.js
+++ b/src/utils/csv.js
@@ -91,19 +91,26 @@ function rowToTransaction(row) {
   if (Number.isNaN(amount)) {
     return { tx: null, error: `Invalid amount: ${sourceAmount}` };
   }
+  /** @type {'income'|'expense'|undefined} */
+  let kind;
   if (row.kind) {
-    const kind = String(row.kind).toLowerCase();
-    if (/(expense|支出|出金|ショッピング|キャッシング)/.test(kind)) {
-      amount = -Math.abs(amount);
-    } else if (/(income|収入|入金)/.test(kind)) {
+    const k = String(row.kind).toLowerCase();
+    if (/(expense|支出|出金|ショッピング|キャッシング)/.test(k)) {
+      kind = 'expense';
+    } else if (/(income|収入|入金)/.test(k)) {
       // TODO: Add more income type keywords if additional deposit kinds are introduced
-      amount = Math.abs(amount);
+      kind = 'income';
     }
   }
+  if (!kind) {
+    kind = amount < 0 ? 'expense' : 'income';
+  }
+  amount = kind === 'expense' ? -Math.abs(amount) : Math.abs(amount);
 
   const tx = {
     date: new Date(dateStr).toISOString().slice(0, 10),
     amount,
+    kind,
   };
   if (row.description) tx.description = row.description;
   if (row.detail) tx.detail = row.detail;


### PR DESCRIPTION
## Summary
- add `kind` field to transactions and persist it
- infer `kind` when importing CSV and ensure sign matches
- update store logic and UI components to filter based on transaction kind

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689adbd570ac832ea03a48fafd656b82