### PR TITLE
feat: toggle income or expense in Others page

### DIFF
--- a/src/OthersTable.jsx
+++ b/src/OthersTable.jsx
@@ -65,18 +65,19 @@ function OthersRow({ row, onAdd, isMobile }) {
  *   rows: { name: string; total: number }[];
  *   addRule: (rule: import('./types').Rule) => void;
  *   isMobile: boolean;
+ *   kind: 'income' | 'expense';
  * }} props
  * `addRule` は新しいルールを上位コンポーネントで保存するためのコールバック。
  * 利用側では `dispatch({ type: 'setRules', payload: [...rules, newRule] })`
  * および `dispatch({ type: 'applyRules' })` を実行する想定。
  */
-export default function OthersTable({ rows, addRule, isMobile }) {
+export default function OthersTable({ rows, addRule, isMobile, kind }) {
   return (
     <table style={{ width: '100%', borderCollapse: 'collapse' }}>
       <thead>
         <tr style={{ textAlign: 'left' }}>
           <th style={{ borderBottom: '1px solid #eee', padding: 6 }}>店舗/内容</th>
-          <th style={{ borderBottom: '1px solid #eee', padding: 6, width: 140 }}>支出合計</th>
+          <th style={{ borderBottom: '1px solid #eee', padding: 6, width: 140 }}>{kind === 'income' ? '収入合計' : '支出合計'}</th>
           <th style={{ borderBottom: '1px solid #eee', padding: 6, width: 260 }}>カテゴリに登録</th>
           <th style={{ borderBottom: '1px solid #eee', padding: 6, width: 100 }} />
         </tr>
@@ -98,7 +99,7 @@ export default function OthersTable({ rows, addRule, isMobile }) {
                 mode,
                 target: 'memo',
                 category: cat,
-                kind: 'expense'
+                kind
               })}
               isMobile={isMobile}
             />

--- a/src/pages/Others.jsx
+++ b/src/pages/Others.jsx
@@ -1,13 +1,14 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import OthersTable from '../OthersTable.jsx';
 import { useStore } from '../state/StoreContext.jsx';
 
 export default function Others() {
   const { state, dispatch } = useStore();
+  const [selectedKind, setSelectedKind] = useState('expense');
   const rows = useMemo(() => {
     const map = {};
     state.transactions
-      .filter((tx) => tx.category === 'その他' && tx.kind === 'expense')
+      .filter((tx) => tx.category === 'その他' && tx.kind === selectedKind)
       .forEach(tx => {
         if (!tx.memo) return;
         map[tx.memo] = (map[tx.memo] || 0) + Math.abs(tx.amount);
@@ -15,7 +16,7 @@ export default function Others() {
     return Object.entries(map)
       .map(([name, total]) => ({ name, total }))
       .sort((a, b) => b.total - a.total);
-  }, [state.transactions]);
+  }, [state.transactions, selectedKind]);
 
   const addRule = newRule => {
     dispatch({ type: 'setRules', payload: [...state.rules, newRule] });
@@ -28,7 +29,13 @@ export default function Others() {
     <section>
       <h2>その他の内訳</h2>
       <div className="card">
-        <OthersTable rows={rows} addRule={addRule} isMobile={isMobile} />
+        <div style={{ marginBottom: 8 }}>
+          <select value={selectedKind} onChange={e => setSelectedKind(e.target.value)}>
+            <option value="expense">支出</option>
+            <option value="income">収入</option>
+          </select>
+        </div>
+        <OthersTable rows={rows} addRule={addRule} isMobile={isMobile} kind={selectedKind} />
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- add a selector on Others page to view income or expense breakdown
- pass kind to OthersTable to adjust column header and rule creation

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689aded52d98832eac561ccc38f2dcab