### PR TITLE
feat: allow custom height for monthly bar chart

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -447,6 +447,7 @@ function Dashboard({
           lockColors={lockColors}
           hideOthers={hideOthers}
           kind={kind}
+          height={350}
         />
       </div>
       <div className='card'>

--- a/src/BarByMonth.jsx
+++ b/src/BarByMonth.jsx
@@ -72,6 +72,7 @@ export default function BarByMonth({
   lockColors,
   hideOthers,
   kind = 'expense',
+  height = 350,
 }) {
   const monthMap = {};
   transactions
@@ -113,7 +114,7 @@ export default function BarByMonth({
   }));
 
   return (
-    <ResponsiveContainer width="100%" height={200}>
+    <ResponsiveContainer width="100%" height={height}>
       <ReBarChart data={dataWithColors} margin={{ top: 8, right: 16, left: 0, bottom: 28 }}>
         <XAxis
           dataKey="month"

--- a/src/pages/Monthly.jsx
+++ b/src/pages/Monthly.jsx
@@ -18,6 +18,7 @@ export default function Monthly({
           lockColors={lockColors}
           hideOthers={hideOthers}
           kind={kind}
+          height={350}
         />
       </div>
     </section>


### PR DESCRIPTION
## Summary
- allow BarByMonth to accept a custom height (default 350px)
- propagate height to Monthly and dashboard usage

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689b00ebafc0832ebf6433e6bfea4f8e