### PR TITLE
Add Supabase connectivity check component

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import './App.css';
 import { useStore } from './state/StoreContext.jsx';
 import BarByMonth from './BarByMonth.jsx';
 import PieByCategory from './PieByCategory.jsx';
+import SupabaseTest from './SupabaseTest.jsx';
 
 const Monthly = lazy(() => import('./pages/Monthly.jsx'));
 const Yearly = lazy(() => import('./pages/Yearly.jsx'));
@@ -218,6 +219,7 @@ export default function App() {
 
   return (
     <div className='app-shell'>
+      {import.meta.env.DEV && <SupabaseTest />}
       {/* ヘッダー */}
       <header className='header'>
         <div className='header-controls'>

--- a/src/SupabaseTest.jsx
+++ b/src/SupabaseTest.jsx
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+import { supabase } from './supabaseClient.js';
+
+export default function SupabaseTest() {
+  useEffect(() => {
+    const testConnection = async () => {
+      const { data, error } = await supabase
+        .from('your_table')
+        .select('*')
+        .limit(1);
+      if (error) {
+        console.error('Supabase error:', error);
+      } else {
+        console.log('Supabase data:', data);
+      }
+    };
+    testConnection();
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- add a lightweight `SupabaseTest` component to verify Supabase queries
- mount the test component in `App.jsx` only in development mode

## Testing
- `VITE_SUPABASE_URL=https://example.supabase.co VITE_SUPABASE_ANON_KEY=examplekey pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_689b018a6154832eb059b78cca6f5e99