### PR TITLE
Handle Supabase client initialization errors

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -9,6 +9,10 @@ npm run dev
 ```
 - ブラウザで http://localhost:5173 を開きます。
 
+- `.env` に以下の環境変数を設定してください:
+  - `VITE_SUPABASE_URL`: Supabase プロジェクトの URL
+  - `VITE_SUPABASE_ANON_KEY`: Supabase の anon key
+
 ## できること
 - 複数CSVのドラッグ＆ドロップ取り込み（SJIS/UTF-8、自動ヘッダースキップ）
 - ルール管理（保存は localStorage）

--- a/src/supabaseClient.js
+++ b/src/supabaseClient.js
@@ -1,12 +1,31 @@
 import { createClient } from '@supabase/supabase-js';
+import React from 'react';
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
-// Fail fast if required environment variables are missing.
-// This prevents the application from starting without a valid Supabase configuration.
-if (!supabaseUrl || !supabaseAnonKey) {
-  throw new Error('Missing VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY');
+let supabase;
+let supabaseError;
+
+try {
+  if (!supabaseUrl || !supabaseAnonKey) {
+    throw new Error('Missing VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY');
+  }
+  supabase = createClient(supabaseUrl, supabaseAnonKey);
+} catch (error) {
+  supabaseError = error;
+  console.error(
+    'Failed to initialize Supabase client. Check VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY:',
+    error,
+  );
 }
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+export { supabase, supabaseError };
+
+export function SupabaseConfigError() {
+  return React.createElement(
+    'div',
+    { className: 'p-4 text-center text-red-600' },
+    'Supabase configuration invalid',
+  );
+}


### PR DESCRIPTION
## Summary
- add try/catch around Supabase client creation and log configuration issues
- expose simple `SupabaseConfigError` component for fallback UI
- document required `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` env vars in Japanese README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b03449ad4832e8c4f597496987956