### PR TITLE
Add monthly category pie chart with selectable month

### DIFF
--- a/src/pages/Monthly.jsx
+++ b/src/pages/Monthly.jsx
@@ -1,4 +1,6 @@
+import { useMemo, useState, useEffect } from 'react';
 import BarByMonth from '../BarByMonth.jsx';
+import PieByCategory from '../PieByCategory.jsx';
 
 export default function Monthly({
   transactions,
@@ -8,6 +10,32 @@ export default function Monthly({
   hideOthers,
   kind,
 }) {
+  const months = useMemo(() => {
+    const set = new Set(
+      transactions
+        .filter((tx) => tx.kind === kind)
+        .map((tx) => tx.date.slice(0, 7)),
+    );
+    return Array.from(set).sort();
+  }, [transactions, kind]);
+
+  const [selectedMonth, setSelectedMonth] = useState(
+    months[months.length - 1] || '',
+  );
+
+  useEffect(() => {
+    setSelectedMonth(months[months.length - 1] || '');
+  }, [months]);
+
+  const monthTxs = useMemo(
+    () =>
+      transactions.filter(
+        (tx) =>
+          tx.kind === kind && tx.date.slice(0, 7) === selectedMonth,
+      ),
+    [transactions, selectedMonth, kind],
+  );
+
   return (
     <section>
       <div className='card'>
@@ -20,6 +48,30 @@ export default function Monthly({
           kind={kind}
           height={350}
         />
+        <div style={{ marginTop: 16 }}>
+          {months.length > 0 && (
+            <div style={{ marginBottom: 8 }}>
+              <select
+                value={selectedMonth}
+                onChange={(e) => setSelectedMonth(e.target.value)}
+              >
+                {months.map((m) => (
+                  <option key={m} value={m}>
+                    {m}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+          <PieByCategory
+            transactions={monthTxs}
+            period="all"
+            yenUnit={yenUnit}
+            lockColors={lockColors}
+            hideOthers={hideOthers}
+            kind={kind}
+          />
+        </div>
       </div>
     </section>
   );


### PR DESCRIPTION
## Summary
- derive unique months from transactions and track selected month
- allow choosing month via dropdown and show category pie chart for that month
- render monthly category pie chart below existing bar chart

## Testing
- `pnpm run build`

------
https://chatgpt.com/codex/tasks/task_e_689b03f88770832eaae0aa575957ce0e