### PR TITLE
feat: add monthly analysis page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import PieByCategory from './PieByCategory.jsx';
 import SupabaseTest from './SupabaseTest.jsx';
 
 const Monthly = lazy(() => import('./pages/Monthly.jsx'));
+const MonthlyAnalysis = lazy(() => import('./pages/MonthlyAnalysis.jsx'));
 const Yearly = lazy(() => import('./pages/Yearly.jsx'));
 const ImportCsv = lazy(() => import('./pages/ImportCsv.jsx'));
 const Rules = lazy(() => import('./pages/Rules.jsx'));
@@ -19,6 +20,7 @@ const NAV = {
   main: [
     { key: 'dashboard', label: 'ダッシュボード' },
     { key: 'monthly', label: '月次比較' },
+    { key: 'analysis', label: '月次分析' },
     { key: 'yearly', label: '年間サマリ' },
   ],
   data: [
@@ -328,6 +330,15 @@ export default function App() {
                 kind={kind}
               />
             </>
+          )}
+          {page === 'analysis' && (
+            <MonthlyAnalysis
+              transactions={state.transactions}
+              period={period}
+              yenUnit={yenUnit}
+              lockColors={lockColors}
+              hideOthers={hideOthers}
+            />
           )}
           {page === 'yearly' && (
             <>

--- a/src/MonthlyComparisonTable.jsx
+++ b/src/MonthlyComparisonTable.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+export default function MonthlyComparisonTable({ rows, selectedMonth, onSelectMonth, yenUnit }) {
+  const formatValue = v =>
+    yenUnit === 'man' ? `${(v / 10000).toFixed(1)} 万円` : `${v.toLocaleString()} 円`;
+  return (
+    <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+      <thead>
+        <tr style={{ textAlign: 'left' }}>
+          <th style={{ borderBottom: '1px solid #eee', padding: 6 }}>月</th>
+          <th style={{ borderBottom: '1px solid #eee', padding: 6 }}>収入</th>
+          <th style={{ borderBottom: '1px solid #eee', padding: 6 }}>支出</th>
+          <th style={{ borderBottom: '1px solid #eee', padding: 6 }}>差分</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map(row => (
+          <tr
+            key={row.month}
+            onClick={() => onSelectMonth(row.month)}
+            style={{
+              backgroundColor: row.month === selectedMonth ? '#f0f8ff' : undefined,
+              cursor: 'pointer'
+            }}
+          >
+            <td style={{ borderBottom: '1px solid #f0f0f0', padding: 6 }}>{row.month}</td>
+            <td style={{ borderBottom: '1px solid #f0f0f0', padding: 6, textAlign: 'right' }}>
+              {formatValue(row.incomeTotal)}
+            </td>
+            <td style={{ borderBottom: '1px solid #f0f0f0', padding: 6, textAlign: 'right' }}>
+              {formatValue(row.expenseTotal)}
+            </td>
+            <td style={{ borderBottom: '1px solid #f0f0f0', padding: 6, textAlign: 'right' }}>
+              {formatValue(row.diff)}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/src/pages/MonthlyAnalysis.jsx
+++ b/src/pages/MonthlyAnalysis.jsx
@@ -1,0 +1,115 @@
+import { useMemo, useState, useEffect } from 'react';
+import PieByCategory from '../PieByCategory.jsx';
+import BarByMonth from '../BarByMonth.jsx';
+import MonthlyComparisonTable from '../MonthlyComparisonTable.jsx';
+
+export default function MonthlyAnalysis({
+  transactions,
+  period,
+  yenUnit,
+  lockColors,
+  hideOthers,
+}) {
+  const months = useMemo(() => {
+    const set = new Set(transactions.map(tx => tx.date.slice(0, 7)));
+    return Array.from(set).sort();
+  }, [transactions]);
+
+  const rows = useMemo(
+    () =>
+      months.map(m => {
+        let incomeTotal = 0;
+        let expenseTotal = 0;
+        transactions.forEach(tx => {
+          if (tx.date.slice(0, 7) !== m) return;
+          if (tx.kind === 'income') incomeTotal += Math.abs(tx.amount);
+          if (tx.kind === 'expense') expenseTotal += Math.abs(tx.amount);
+        });
+        return { month: m, incomeTotal, expenseTotal, diff: incomeTotal - expenseTotal };
+      }),
+    [months, transactions],
+  );
+
+  const [selectedMonth, setSelectedMonth] = useState(months[months.length - 1] || '');
+
+  useEffect(() => {
+    setSelectedMonth(months[months.length - 1] || '');
+  }, [months]);
+
+  const monthTxs = useMemo(
+    () => transactions.filter(tx => tx.date.slice(0, 7) === selectedMonth),
+    [transactions, selectedMonth],
+  );
+
+  return (
+    <section>
+      <div className='card'>
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 16 }}>
+          <div style={{ flex: 1, minWidth: 300 }}>
+            <BarByMonth
+              transactions={transactions}
+              period={period}
+              yenUnit={yenUnit}
+              lockColors={lockColors}
+              hideOthers={hideOthers}
+              kind='expense'
+              height={200}
+            />
+          </div>
+          <div style={{ flex: 1, minWidth: 300 }}>
+            <BarByMonth
+              transactions={transactions}
+              period={period}
+              yenUnit={yenUnit}
+              lockColors={lockColors}
+              hideOthers={hideOthers}
+              kind='income'
+              height={200}
+            />
+          </div>
+        </div>
+        <div style={{ marginTop: 16 }}>
+          <MonthlyComparisonTable
+            rows={rows}
+            selectedMonth={selectedMonth}
+            onSelectMonth={setSelectedMonth}
+            yenUnit={yenUnit}
+          />
+          {months.length > 0 && (
+            <div style={{ marginTop: 8 }}>
+              <select value={selectedMonth} onChange={e => setSelectedMonth(e.target.value)}>
+                {months.map(m => (
+                  <option key={m} value={m}>
+                    {m}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 16, marginTop: 16 }}>
+            <div style={{ flex: 1, minWidth: 300 }}>
+              <PieByCategory
+                transactions={monthTxs}
+                period='all'
+                yenUnit={yenUnit}
+                lockColors={lockColors}
+                hideOthers={hideOthers}
+                kind='expense'
+              />
+            </div>
+            <div style={{ flex: 1, minWidth: 300 }}>
+              <PieByCategory
+                transactions={monthTxs}
+                period='all'
+                yenUnit={yenUnit}
+                lockColors={lockColors}
+                hideOthers={hideOthers}
+                kind='income'
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add MonthlyAnalysis page with monthly income/expense comparison table
- show pie and bar charts for selected month
- wire up navigation to new page

## Testing
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689b06ee4524832e86cbd8dfd434536d