### PR TITLE
feat: centralize currency formatting

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -376,7 +376,7 @@ export default function App() {
           )}
           {page === 'import' && <ImportCsv />}
           {page === 'rules' && <Rules />}
-          {page === 'others' && <Others />}
+          {page === 'others' && <Others yenUnit={yenUnit} />}
           {page === 'tx' && <Transactions />}
           {page === 'prefs' && <Prefs />}
         </Suspense>

--- a/src/BarByMonth.jsx
+++ b/src/BarByMonth.jsx
@@ -1,4 +1,5 @@
 import { useRef, useMemo } from 'react';
+import { convertAmount, formatAmount } from './utils/currency.js';
 import {
   ResponsiveContainer,
   BarChart as ReBarChart,
@@ -101,9 +102,11 @@ export default function BarByMonth({
     return data.map((d) => ({ ...d, fill: colorMap.current[d.month] }));
   }, [data, lockColors]);
 
-  const tickFormatter = (v) => (yenUnit === 'man' ? (v / 10000).toFixed(1) : v);
-  const formatValue = (v) =>
-    yenUnit === 'man' ? `${(v / 10000).toFixed(1)} 万円` : `${v} 円`;
+  const tickFormatter = (v) => {
+    const value = convertAmount(v, yenUnit);
+    return yenUnit === 'man' ? value.toFixed(1) : value.toLocaleString();
+  };
+  const formatValue = (v) => formatAmount(v, yenUnit);
   const tooltipFormatter = (v) => [formatValue(v), '合計'];
   const legendPayload = dataWithColors.map((d) => ({
     id: d.month,

--- a/src/NetBalance.jsx
+++ b/src/NetBalance.jsx
@@ -1,3 +1,5 @@
+import { formatAmount } from './utils/currency.js';
+
 export default function NetBalance({ transactions, period, yenUnit }) {
   const monthMap = {};
   transactions.forEach((tx) => {
@@ -21,25 +23,19 @@ export default function NetBalance({ transactions, period, yenUnit }) {
 
   const diff = incomeTotal - expenseTotal;
 
-  const format = (v) => {
-    const value = yenUnit === 'man' ? v / 10000 : v;
-    const unit = yenUnit === 'man' ? '万円' : '円';
-    return `${value.toLocaleString()} ${unit}`;
-  };
-
   return (
     <div className='net-balance'>
       <div className='net-balance-row'>
         <span>収入</span>
-        <span>{format(incomeTotal)}</span>
+        <span>{formatAmount(incomeTotal, yenUnit)}</span>
       </div>
       <div className='net-balance-row'>
         <span>支出</span>
-        <span>{format(expenseTotal)}</span>
+        <span>{formatAmount(expenseTotal, yenUnit)}</span>
       </div>
       <div className={`net-balance-row${diff < 0 ? ' negative' : ''}`}>
         <span>差分</span>
-        <span>{format(diff)}</span>
+        <span>{formatAmount(diff, yenUnit)}</span>
       </div>
     </div>
   );

--- a/src/OthersTable.jsx
+++ b/src/OthersTable.jsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
 import FullScreenModal from './FullScreenModal';
 import { CATEGORIES } from './categories';
+import { formatAmount } from './utils/currency.js';
 
-function OthersRow({ row, onAdd, isMobile }) {
+function OthersRow({ row, onAdd, isMobile, yenUnit }) {
   const [cat, setCat] = useState('食費');
   const [mode, setMode] = useState('contains');
   const [open, setOpen] = useState(false);
@@ -18,7 +19,7 @@ function OthersRow({ row, onAdd, isMobile }) {
         {row.name}
       </td>
       <td style={{ borderBottom: '1px solid #f0f0f0', padding: 6 }}>
-        {row.total.toLocaleString()} 円
+        {formatAmount(row.total, yenUnit)}
       </td>
       <td style={{ borderBottom: '1px solid #f0f0f0', padding: 6 }}>
         {isMobile ? (
@@ -66,12 +67,13 @@ function OthersRow({ row, onAdd, isMobile }) {
  *   addRule: (rule: import('./types').Rule) => void;
  *   isMobile: boolean;
  *   kind: 'income' | 'expense';
+ *   yenUnit: 'yen' | 'man';
  * }} props
  * `addRule` は新しいルールを上位コンポーネントで保存するためのコールバック。
  * 利用側では `dispatch({ type: 'setRules', payload: [...rules, newRule] })`
  * および `dispatch({ type: 'applyRules' })` を実行する想定。
  */
-export default function OthersTable({ rows, addRule, isMobile, kind }) {
+export default function OthersTable({ rows, addRule, isMobile, kind, yenUnit }) {
   return (
     <table style={{ width: '100%', borderCollapse: 'collapse' }}>
       <thead>
@@ -102,6 +104,7 @@ export default function OthersTable({ rows, addRule, isMobile, kind }) {
                 kind
               })}
               isMobile={isMobile}
+              yenUnit={yenUnit}
             />
           ))
         )}

--- a/src/PieByCategory.jsx
+++ b/src/PieByCategory.jsx
@@ -1,4 +1,5 @@
 import { useRef, useMemo } from 'react';
+import { formatAmount } from './utils/currency.js';
 import {
   ResponsiveContainer,
   PieChart as RePieChart,
@@ -115,8 +116,7 @@ export default function PieByCategory({
     return items.map((d) => ({ ...d, fill: colorMap.current[d.name] }));
   }, [items, lockColors]);
 
-  const formatValue = (v) =>
-    yenUnit === 'man' ? `${(v / 10000).toFixed(1)} 万円` : `${v} 円`;
+  const formatValue = (v) => formatAmount(v, yenUnit);
   const tooltipFormatter = (v, name) => [formatValue(v), name];
   const legendPayload = dataWithColors.map((item) => ({
     id: item.name,

--- a/src/pages/Others.jsx
+++ b/src/pages/Others.jsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from 'react';
 import OthersTable from '../OthersTable.jsx';
 import { useStore } from '../state/StoreContext.jsx';
 
-export default function Others() {
+export default function Others({ yenUnit }) {
   const { state, dispatch } = useStore();
   const [selectedKind, setSelectedKind] = useState('expense');
   const rows = useMemo(() => {
@@ -35,7 +35,13 @@ export default function Others() {
             <option value="income">収入</option>
           </select>
         </div>
-        <OthersTable rows={rows} addRule={addRule} isMobile={isMobile} kind={selectedKind} />
+        <OthersTable
+          rows={rows}
+          addRule={addRule}
+          isMobile={isMobile}
+          kind={selectedKind}
+          yenUnit={yenUnit}
+        />
       </div>
     </section>
   );

--- a/src/utils/currency.js
+++ b/src/utils/currency.js
@@ -1,0 +1,13 @@
+export function convertAmount(amount, unit) {
+  return unit === 'man' ? amount / 10000 : amount;
+}
+
+export function formatAmount(amount, unit) {
+  const value = convertAmount(amount, unit);
+  if (unit === 'man') {
+    return `${value.toLocaleString(undefined, { minimumFractionDigits: 1, maximumFractionDigits: 1 })} 万円`;
+  }
+  return `${value.toLocaleString()} 円`;
+}
+
+export default { convertAmount, formatAmount };

--- a/src/utils/currency.test.js
+++ b/src/utils/currency.test.js
@@ -1,0 +1,10 @@
+import assert from 'assert';
+import { convertAmount, formatAmount } from './currency.js';
+
+assert.strictEqual(convertAmount(20000, 'yen'), 20000);
+assert.strictEqual(convertAmount(20000, 'man'), 2);
+
+assert.strictEqual(formatAmount(20000, 'yen'), '20,000 円');
+assert.strictEqual(formatAmount(20000, 'man'), '2.0 万円');
+
+console.log('currency utils ok');


### PR DESCRIPTION
## Summary
- add currency conversion & formatting helpers
- use helpers across dashboard components to honor yen unit toggle
- cover currency helpers with a small test

## Testing
- `node src/utils/currency.test.js`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b08c0dee4832e8527815d08cce97d