### PR TITLE
Rename app to 家計簿

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "household-ledger-miniapp",
+  "name": "kakeibo-miniapp",
   "private": true,
   "version": "0.0.1",
   "type": "module",

--- a/vite.config.js
+++ b/vite.config.js
@@ -10,8 +10,8 @@ export default defineConfig({
       registerType: "autoUpdate",
       includeAssets: ["/icons/favicon-32.png"],
       manifest: {
-        name: "Ledger Mini App",
-        short_name: "Ledger",
+        name: "家計簿ミニアプリ",
+        short_name: "家計簿",
         start_url: "/",
         display: "standalone",
         background_color: "#ffffff",


### PR DESCRIPTION
## Summary
- change project name to `kakeibo-miniapp`
- update PWA manifest to display the app as 家計簿

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_689b0927968c832ebf586b09ed401a7a