### PR TITLE
Enable horizontal scrolling for monthly bar charts

### DIFF
--- a/src/BarByMonth.jsx
+++ b/src/BarByMonth.jsx
@@ -90,6 +90,8 @@ export default function BarByMonth({
     .slice(-limit)
     .map((m) => ({ month: m, total: monthMap[m] }));
 
+  const width = data.length * 40;
+
   const colorMap = useRef({});
   const dataWithColors = useMemo(() => {
     if (!lockColors) colorMap.current = {};
@@ -117,7 +119,7 @@ export default function BarByMonth({
   }));
 
   return (
-    <ResponsiveContainer width="100%" height={height}>
+    <ResponsiveContainer width={width} height={height}>
       <ReBarChart data={dataWithColors} margin={{ top: 8, right: 16, left: 0, bottom: 28 }}>
         <XAxis
           dataKey="month"

--- a/src/pages/MonthlyAnalysis.jsx
+++ b/src/pages/MonthlyAnalysis.jsx
@@ -49,26 +49,30 @@ export default function MonthlyAnalysis({
       <div className='card'>
         <div style={{ display: 'flex', flexWrap: 'wrap', gap: 16 }}>
           <div style={{ flex: 1, minWidth: 300 }}>
-            <BarByMonth
-              transactions={transactions}
-              period={period}
-              yenUnit={yenUnit}
-              lockColors={lockColors}
-              hideOthers={hideOthers}
-              kind='expense'
-              height={200}
-            />
+            <div style={{ overflowX: 'auto' }}>
+              <BarByMonth
+                transactions={transactions}
+                period={period}
+                yenUnit={yenUnit}
+                lockColors={lockColors}
+                hideOthers={hideOthers}
+                kind='expense'
+                height={200}
+              />
+            </div>
           </div>
           <div style={{ flex: 1, minWidth: 300 }}>
-            <BarByMonth
-              transactions={transactions}
-              period={period}
-              yenUnit={yenUnit}
-              lockColors={lockColors}
-              hideOthers={hideOthers}
-              kind='income'
-              height={200}
-            />
+            <div style={{ overflowX: 'auto' }}>
+              <BarByMonth
+                transactions={transactions}
+                period={period}
+                yenUnit={yenUnit}
+                lockColors={lockColors}
+                hideOthers={hideOthers}
+                kind='income'
+                height={200}
+              />
+            </div>
           </div>
         </div>
         <div style={{ marginTop: 16 }}>


### PR DESCRIPTION
## Summary
- Wrap monthly bar charts in horizontally scrollable containers
- Add dynamic width to bar chart component so parent can scroll

## Testing
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689b0cc5a8e0832ebfa7f564780e9c1a