### PR TITLE
Add headings to monthly analysis pie charts

### DIFF
--- a/src/pages/MonthlyAnalysis.jsx
+++ b/src/pages/MonthlyAnalysis.jsx
@@ -91,6 +91,7 @@ export default function MonthlyAnalysis({
           )}
           <div style={{ display: 'flex', flexWrap: 'wrap', gap: 16, marginTop: 16 }}>
             <div style={{ flex: 1, minWidth: 300 }}>
+              <h3 style={{ textAlign: 'center', marginBottom: 8 }}>支出</h3>
               <PieByCategory
                 transactions={monthTxs}
                 period='all'
@@ -101,6 +102,7 @@ export default function MonthlyAnalysis({
               />
             </div>
             <div style={{ flex: 1, minWidth: 300 }}>
+              <h3 style={{ textAlign: 'center', marginBottom: 8 }}>収入</h3>
               <PieByCategory
                 transactions={monthTxs}
                 period='all'


### PR DESCRIPTION
## Summary
- add "支出" and "収入" headings above monthly analysis pie charts

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_689b0d461910832e9b8a4887422ee318