### PR TITLE
refactor: ensure hooks run before auth check

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -74,11 +74,7 @@ export default function App() {
   const { state, dispatch } = useStore();
   const session = useSession();
   const isLocalMode = localStorage.getItem('localMode') === 'true';
-  
-  // Show auth screen if not logged in and not in local mode
-  if (!session && !isLocalMode) {
-    return <Auth onSkipAuth={() => window.location.reload()} />;
-  }
+  const isAuthenticated = session || isLocalMode;
   const getInitial = () => {
     const h = parseHash(window.location.hash || '');
     const stored = {
@@ -239,6 +235,10 @@ export default function App() {
     return () => panel.removeEventListener('keydown', onKey);
   }, [open]);
 
+  if (!isAuthenticated) {
+    return <Auth onSkipAuth={() => window.location.reload()} />;
+  }
+
   return (
     <div className='app-shell'>
       {/* ヘッダー */}
@@ -286,7 +286,7 @@ export default function App() {
           {NAV.settings.map(i => (
             <NavItem key={i.key} active={page === i.key} onClick={() => go(i.key)}>{i.label}</NavItem>
           ))}
-          {(session || isLocalMode) && (
+          {isAuthenticated && (
             <>
               <h4>アカウント</h4>
               {session ? (


### PR DESCRIPTION
## Summary
- ensure hooks run consistently by declaring them before the auth check
- gate unauthenticated users with `<Auth>` after hooks execute

## Testing
- `pnpm run test` *(fails: Missing script: test)*

------
https://chatgpt.com/codex/tasks/task_e_689b20e79d98832eb9bf80cd15974a66