### PR TITLE
Add button type to Google login to prevent unintended submits

### DIFF
--- a/src/components/Auth.jsx
+++ b/src/components/Auth.jsx
@@ -143,6 +143,7 @@ export default function Auth({ onSkipAuth }) {
         </div>
 
         <button
+          type="button"
           onClick={handleGoogleSignIn}
           className="auth-button google"
           disabled={loading}


### PR DESCRIPTION
## Summary
- prevent the Google login button from behaving as a submit button by explicitly setting `type="button"`

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689b37b8f964832e9f10e0114a2841f1