### PR TITLE
Disable Google login when Supabase is missing

### DIFF
--- a/src/components/Auth.jsx
+++ b/src/components/Auth.jsx
@@ -146,10 +146,23 @@ export default function Auth({ onSkipAuth }) {
           type="button"
           onClick={handleGoogleSignIn}
           className="auth-button google"
-          disabled={loading}
+          disabled={loading || !supabase}
         >
           Google でログイン
         </button>
+        {!supabase && (
+          <p
+            style={{
+              fontSize: '0.75rem',
+              color: '#dc2626',
+              textAlign: 'center',
+              marginTop: '-0.5rem',
+              marginBottom: '1rem',
+            }}
+          >
+            Supabase設定が必要
+          </p>
+        )}
 
         <form onSubmit={handleAuth} className="auth-form">
           <div className="form-group">


### PR DESCRIPTION
## Summary
- Disable Google sign-in button when Supabase client is unavailable
- Display help message indicating Supabase setup is required

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689b388509a4832e9e4c895303559502