### PR TITLE
feat(auth): add GitHub OAuth sign-in

### DIFF
--- a/src/components/Auth.css
+++ b/src/components/Auth.css
@@ -120,16 +120,25 @@
   box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
 }
 
-.auth-button.google {
+.auth-button.oauth {
   background: white;
   color: #374151;
   border: 1px solid #d1d5db;
+}
+
+.auth-button.oauth:hover:not(:disabled) {
+  background: #f9fafb;
+  border-color: #9ca3af;
+}
+
+.oauth-buttons {
+  display: flex;
+  gap: 1rem;
   margin-bottom: 1rem;
 }
 
-.auth-button.google:hover:not(:disabled) {
-  background: #f9fafb;
-  border-color: #9ca3af;
+.oauth-buttons .auth-button {
+  flex: 1;
 }
 
 .auth-button:disabled {

--- a/src/components/Auth.jsx
+++ b/src/components/Auth.jsx
@@ -89,6 +89,35 @@ export default function Auth({ onSkipAuth }) {
     }
   };
 
+  const handleGitHubSignIn = async () => {
+    if (!supabase) {
+      setError('Supabase接続が利用できません。ローカルモードをご利用ください。');
+      return;
+    }
+
+    setLoading(true);
+    setError('');
+
+    try {
+      const { data, error } = await supabase.auth.signInWithOAuth({
+        provider: 'github',
+        options: {
+          redirectTo: window.location.origin,
+          scopes: 'read:user user:email',
+        },
+      });
+
+      if (error) throw error;
+
+      if (data?.url) window.location.href = data.url;
+    } catch (error) {
+      setError(error.message);
+      alert(error.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
   const handleLocalMode = () => {
     // ローカルストレージモードで起動
     localStorage.setItem('localMode', 'true');
@@ -142,14 +171,24 @@ export default function Auth({ onSkipAuth }) {
           <span>または</span>
         </div>
 
-        <button
-          type="button"
-          onClick={handleGoogleSignIn}
-          className="auth-button google"
-          disabled={loading || !supabase}
-        >
-          Google でログイン
-        </button>
+        <div className="oauth-buttons">
+          <button
+            type="button"
+            onClick={handleGoogleSignIn}
+            className="auth-button oauth"
+            disabled={loading || !supabase}
+          >
+            Google でログイン
+          </button>
+          <button
+            type="button"
+            onClick={handleGitHubSignIn}
+            className="auth-button oauth"
+            disabled={loading || !supabase}
+          >
+            GitHubでサインイン
+          </button>
+        </div>
         {!supabase && (
           <p
             style={{


### PR DESCRIPTION
## Summary
- add GitHub OAuth login alongside Google
- style OAuth buttons uniformly

## Testing
- `pnpm lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_689bd9f722e4832ebd290676a4ca39a2