### PR TITLE
Add password reset flow with routing integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "papaparse": "^5.5.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-router-dom": "^7.8.0",
     "recharts": "^2.12.6",
     "workbox-window": "^7.3.0",
     "xlsx": "^0.18.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      react-router-dom:
+        specifier: ^7.8.0
+        version: 7.8.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       recharts:
         specifier: ^2.12.6
         version: 2.15.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1340,6 +1343,10 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie@1.0.2:
+    resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
+    engines: {node: '>=18'}
+
   core-js-compat@3.45.0:
     resolution: {integrity: sha512-gRoVMBawZg0OnxaVv3zpqLLxaHmsubEGyTnqdpI/CEBvX4JadI1dMSHxagThprYRtSVbuQxvi6iUatdPxohHpA==}
 
@@ -2265,6 +2272,23 @@ packages:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
 
+  react-router-dom@7.8.0:
+    resolution: {integrity: sha512-ntInsnDVnVRdtSu6ODmTQ41cbluak/ENeTif7GBce0L6eztFg6/e1hXAysFQI8X25C8ipKmT9cClbJwxx3Kaqw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+
+  react-router@7.8.0:
+    resolution: {integrity: sha512-r15M3+LHKgM4SOapNmsH3smAizWds1vJ0Z9C4mWaKnT9/wD7+d/0jYcj6LmOvonkrO4Rgdyp4KQ/29gWN2i1eg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react-smooth@4.0.4:
     resolution: {integrity: sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==}
     peerDependencies:
@@ -2387,6 +2411,9 @@ packages:
 
   serialize-javascript@6.0.2:
     resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
+
+  set-cookie-parser@2.7.1:
+    resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -4183,6 +4210,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie@1.0.2: {}
+
   core-js-compat@3.45.0:
     dependencies:
       browserslist: 4.25.2
@@ -5187,6 +5216,20 @@ snapshots:
 
   react-refresh@0.17.0: {}
 
+  react-router-dom@7.8.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-router: 7.8.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+
+  react-router@7.8.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      cookie: 1.0.2
+      react: 18.3.1
+      set-cookie-parser: 2.7.1
+    optionalDependencies:
+      react-dom: 18.3.1(react@18.3.1)
+
   react-smooth@4.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       fast-equals: 5.2.2
@@ -5360,6 +5403,8 @@ snapshots:
   serialize-javascript@6.0.2:
     dependencies:
       randombytes: 2.1.0
+
+  set-cookie-parser@2.7.1: {}
 
   set-function-length@1.2.2:
     dependencies:

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -680,10 +680,13 @@ function Dashboard({
 .error-boundary button{margin-top:.5rem;padding:.4rem .8rem;border:1px solid var(--line);border-radius:.5rem;background:#fafafa;cursor:pointer}
 .pwa-refresh{position:fixed;bottom:1rem;left:50%;transform:translateX(-50%);display:flex;gap:.5rem;align-items:center;padding:.5rem 1rem;background:#1e3a8a;color:#fff;border-radius:.5rem;z-index:50}
 .pwa-refresh button{background:#fff;color:#1e3a8a;border:none;padding:.3rem .6rem;border-radius:.3rem;cursor:pointer}
-@media(min-width:1024px){
-  .drawer{display:block;background:transparent;position:sticky;inset:auto}
-  .drawer-panel{position:fixed;right:0;left:auto;top:0;bottom:0}
-  .content{margin-right:min(82vw,320px);margin-left:0}
+  @media(min-width:1024px){
+    .drawer{display:block;background:transparent;position:sticky;inset:auto}
+    .drawer-panel{position:fixed;right:0;left:auto;top:0;bottom:0}
+    .content{margin-right:min(82vw,320px);margin-left:0}
+  }
+  `}</style>
+
+</section>
+  );
 }
-`;
-`}</style>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,7 +1,10 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
 import "./index.css";
 import App from "./App.jsx";
+import ForgotPassword from "./pages/ForgotPassword.jsx";
+import PasswordResetCallback from "./pages/PasswordResetCallback.jsx";
 import { StoreProvider } from "./state/StoreContextWithDB.jsx";
 import ErrorBoundary from "./ErrorBoundary.jsx";
 import { initErrorLogger } from "./errorLogger.js";
@@ -9,9 +12,15 @@ import { initErrorLogger } from "./errorLogger.js";
 initErrorLogger();
 
 createRoot(document.getElementById("root")).render(
-  <ErrorBoundary>
-    <StoreProvider>
-      <App />
-    </StoreProvider>
-  </ErrorBoundary>
+  <BrowserRouter>
+    <ErrorBoundary>
+      <StoreProvider>
+        <Routes>
+          <Route path="/forgot" element={<ForgotPassword />} />
+          <Route path="/auth/callback" element={<PasswordResetCallback />} />
+          <Route path="/*" element={<App />} />
+        </Routes>
+      </StoreProvider>
+    </ErrorBoundary>
+  </BrowserRouter>
 );

--- a/src/pages/ForgotPassword.jsx
+++ b/src/pages/ForgotPassword.jsx
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+import { supabase } from '../supabaseClient';
+
+export default function ForgotPassword() {
+  const [email, setEmail] = useState('');
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    if (!supabase) {
+      setError('Supabase接続が利用できません。');
+      return;
+    }
+    setLoading(true);
+    setMessage('');
+    setError('');
+    try {
+      const { error } = await supabase.auth.resetPasswordForEmail(email, {
+        redirectTo: `${window.location.origin}/auth/callback`,
+      });
+      if (error) throw error;
+      setMessage('パスワードリセット用のメールを送信しました。');
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <section className='card' style={{ maxWidth: 400, margin: '40px auto' }}>
+      <h2>パスワードリセット</h2>
+      {message && <p style={{ color: 'green' }}>{message}</p>}
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        <label>
+          メールアドレス
+          <input
+            type='email'
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+            required
+          />
+        </label>
+        <button type='submit' disabled={loading}>
+          メール送信
+        </button>
+      </form>
+    </section>
+  );
+}

--- a/src/pages/PasswordResetCallback.jsx
+++ b/src/pages/PasswordResetCallback.jsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '../supabaseClient';
+
+export default function PasswordResetCallback() {
+  const [password, setPassword] = useState('');
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    const code = new URLSearchParams(window.location.search).get('code');
+    if (!supabase) {
+      setError('Supabase接続が利用できません。');
+      setReady(true);
+      return;
+    }
+    if (!code) {
+      setError('コードが見つかりません。');
+      setReady(true);
+      return;
+    }
+    supabase.auth.exchangeCodeForSession(code).then(({ error }) => {
+      if (error) setError(error.message);
+      setReady(true);
+    });
+  }, []);
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    if (!supabase) {
+      setError('Supabase接続が利用できません。');
+      return;
+    }
+    setLoading(true);
+    setMessage('');
+    setError('');
+    try {
+      const { error } = await supabase.auth.updateUser({ password });
+      if (error) throw error;
+      setMessage('パスワードを更新しました。');
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!ready) {
+    return <p>読み込み中...</p>;
+  }
+
+  return (
+    <section className='card' style={{ maxWidth: 400, margin: '40px auto' }}>
+      <h2>新しいパスワードを設定</h2>
+      {message && <p style={{ color: 'green' }}>{message}</p>}
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        <label>
+          パスワード
+          <input
+            type='password'
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+            required
+          />
+        </label>
+        <button type='submit' disabled={loading}>
+          更新
+        </button>
+      </form>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add react-router-dom for routing
- implement ForgotPassword and PasswordResetCallback pages using Supabase auth
- wire up BrowserRouter with routes for password reset flow

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689bdefc0a30832e9f04c21938ebeb2c