### PR TITLE
feat: add forgot password page

### DIFF
--- a/src/pages/ForgotPassword.jsx
+++ b/src/pages/ForgotPassword.jsx
@@ -1,0 +1,64 @@
+import { useState } from 'react';
+import { supabase } from '../supabaseClient.js';
+
+export default function ForgotPassword() {
+  const [email, setEmail] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    if (!supabase) {
+      setError('Supabase接続が利用できません。');
+      return;
+    }
+    setLoading(true);
+    setMessage('');
+    setError('');
+    try {
+      const { error } = await supabase.auth.resetPasswordForEmail(email, {
+        redirectTo: window.location.origin + '/auth/callback',
+      });
+      if (error) throw error;
+      setMessage('パスワード再設定用のメールを送信しました。');
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <section>
+      <h2>パスワード再発行</h2>
+      <div className='card'>
+        {message && (
+          <p role='status' style={{ color: '#16a34a' }}>
+            {message}
+          </p>
+        )}
+        {error && (
+          <p role='alert' style={{ color: '#dc2626' }}>
+            {error}
+          </p>
+        )}
+        <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '.75rem' }}>
+          <label htmlFor='email'>メールアドレス</label>
+          <input
+            id='email'
+            type='email'
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+            required
+            pattern='[^\s@]+@[^\s@]+\.[^\s@]+'
+            disabled={loading}
+          />
+          <button type='submit' disabled={loading}>
+            {loading ? '送信中...' : '送信'}
+          </button>
+        </form>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add ForgotPassword page with accessible email form and Supabase reset

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bdfba834c832e97cd593845f9d4f4