### PR TITLE
feat: add GitHub auth and toast notifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "papaparse": "^5.5.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-hot-toast": "^2.5.2",
     "recharts": "^2.12.6",
     "workbox-window": "^7.3.0",
     "xlsx": "^0.18.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      react-hot-toast:
+        specifier: ^2.5.2
+        version: 2.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       recharts:
         specifier: ^2.12.6
         version: 2.15.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1928,6 +1931,11 @@ packages:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
 
+  goober@2.1.16:
+    resolution: {integrity: sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==}
+    peerDependencies:
+      csstype: ^3.0.10
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -2584,6 +2592,13 @@ packages:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
       react: ^18.3.1
+
+  react-hot-toast@2.5.2:
+    resolution: {integrity: sha512-Tun3BbCxzmXXM7C+NI4qiv6lT0uwGh4oAfeJyNOjYUejTsm35mK9iCaYLGv8cBz9L5YxZLx/2ii7zsIwPtPUdw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: '>=16'
+      react-dom: '>=16'
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -5392,6 +5407,10 @@ snapshots:
       define-properties: 1.2.1
       gopd: 1.2.0
 
+  goober@2.1.16(csstype@3.1.3):
+    dependencies:
+      csstype: 3.1.3
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
@@ -5983,6 +6002,13 @@ snapshots:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
+
+  react-hot-toast@2.5.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      csstype: 3.1.3
+      goober: 2.1.16(csstype@3.1.3)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   react-is@16.13.1: {}
 

--- a/src/components/Auth.css
+++ b/src/components/Auth.css
@@ -132,6 +132,23 @@
   border-color: #9ca3af;
 }
 
+.auth-social-buttons {
+  display: flex;
+  gap: 1rem;
+}
+
+.auth-button.github {
+  background: white;
+  color: #374151;
+  border: 1px solid #d1d5db;
+  margin-bottom: 1rem;
+}
+
+.auth-button.github:hover:not(:disabled) {
+  background: #f9fafb;
+  border-color: #9ca3af;
+}
+
 .auth-button:disabled {
   opacity: 0.5;
   cursor: not-allowed;

--- a/src/components/Auth.jsx
+++ b/src/components/Auth.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { supabase } from '../lib/supabaseClient.js';
+import { toast } from 'react-hot-toast';
 import './Auth.css';
 
 export default function Auth({ onSkipAuth }) {
@@ -98,6 +99,35 @@ export default function Auth({ onSkipAuth }) {
     }
   };
 
+  const handleGitHubSignIn = async () => {
+    if (!supabase) {
+      setError('Supabase接続が利用できません。ローカルモードをご利用ください。');
+      return;
+    }
+
+    setLoading(true);
+    setError('');
+
+    try {
+      const { data, error } = await supabase.auth.signInWithOAuth({
+        provider: 'github',
+        options: {
+          redirectTo: window.location.origin,
+          scopes: 'read:user user:email',
+        },
+      });
+
+      if (error) throw error;
+
+      if (data?.url) window.location.href = data.url;
+    } catch (error) {
+      toast.error(error.message);
+      setError('');
+    } finally {
+      setLoading(false);
+    }
+  };
+
   const handlePasswordReset = async () => {
     if (!supabase) {
       setError('Supabase接続が利用できません。ローカルモードをご利用ください。');
@@ -173,15 +203,24 @@ export default function Auth({ onSkipAuth }) {
         <div className="auth-divider">
           <span>または</span>
         </div>
-
-        <button
-          type="button"
-          onClick={handleGoogleSignIn}
-          className="auth-button google"
-          disabled={loading || !supabase}
-        >
-          Google でログイン
-        </button>
+        <div className="auth-social-buttons">
+          <button
+            type="button"
+            onClick={handleGoogleSignIn}
+            className="auth-button google"
+            disabled={loading || !supabase}
+          >
+            Google でログイン
+          </button>
+          <button
+            type="button"
+            onClick={handleGitHubSignIn}
+            className="auth-button github"
+            disabled={loading || !supabase}
+          >
+            GitHub でログイン
+          </button>
+        </div>
         {!supabase && (
           <p
             style={{

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -5,12 +5,14 @@ import App from "./App.jsx";
 import { StoreProvider } from "./state/StoreContextWithDB.jsx";
 import ErrorBoundary from "./ErrorBoundary.jsx";
 import { initErrorLogger } from "./errorLogger.js";
+import { Toaster } from "react-hot-toast";
 
 initErrorLogger();
 
 createRoot(document.getElementById("root")).render(
   <ErrorBoundary>
     <StoreProvider>
+      <Toaster position="top-right" />
       <App />
     </StoreProvider>
   </ErrorBoundary>


### PR DESCRIPTION
## Summary
- add react-hot-toast Toaster root component
- implement GitHub OAuth sign-in with toast error handling
- align Google and GitHub auth buttons with shared styling

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689be1d4135c832e9f7a38297a95fee0