### PR TITLE
feat: localize auth error messages

### DIFF
--- a/src/components/Auth.jsx
+++ b/src/components/Auth.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { supabase } from '../lib/supabaseClient.js';
+import { normalizeAuthError } from '../utils/authErrors.js';
 import './Auth.css';
 
 export default function Auth({ onSkipAuth }) {
@@ -9,15 +10,6 @@ export default function Auth({ onSkipAuth }) {
   const [isSignUp, setIsSignUp] = useState(false);
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
-
-  const normalizeAuthError = (error) => {
-    if (!error?.message) return '';
-    return error.message === 'Invalid login credentials'
-      ? 'メールアドレスまたはパスワードが正しくありません。'
-      : error.message.includes('Email address') && error.message.includes('invalid')
-      ? '有効なメールアドレスを入力してください（例: your-email@gmail.com）'
-      : error.message;
-  };
 
   const handleAuth = async (e) => {
     e.preventDefault();
@@ -63,11 +55,7 @@ export default function Auth({ onSkipAuth }) {
         window.location.reload();
       }
     } catch (error) {
-      setError(error.message === 'Invalid login credentials' 
-        ? 'メールアドレスまたはパスワードが正しくありません。' 
-        : error.message.includes('Email address') && error.message.includes('invalid')
-        ? '有効なメールアドレスを入力してください（例: your-email@gmail.com）'
-        : error.message);
+      setError(normalizeAuthError(error));
     } finally {
       setLoading(false);
     }

--- a/src/utils/authErrors.js
+++ b/src/utils/authErrors.js
@@ -1,0 +1,13 @@
+export function normalizeAuthError(error) {
+  const message = error?.message || '';
+  if (message === 'Invalid login credentials') {
+    return 'メールアドレスまたはパスワードが正しくありません。';
+  }
+  if (message === 'Email not confirmed') {
+    return 'メールアドレスが確認されていません。メールをご確認ください。';
+  }
+  if (message.toLowerCase().includes('rate limit') || error?.status === 429) {
+    return '一定回数を超過しました。しばらく待ってから再度お試しください。';
+  }
+  return message;
+}


### PR DESCRIPTION
## Summary
- centralize Supabase auth error handling
- display friendly localized messages for sign-in and password reset errors

## Testing
- `pnpm lint`
- `pnpm test` *(no tests configured)*

------
https://chatgpt.com/codex/tasks/task_e_689be29894e4832e9d0ce0438d2eaf5a