### PR TITLE
Add password reset callback e2e test

### DIFF
--- a/cypress/e2e/callback.cy.js
+++ b/cypress/e2e/callback.cy.js
@@ -1,0 +1,23 @@
+describe('Password Reset Callback', () => {
+  it('updates password and shows success message with login link', () => {
+    cy.intercept('PUT', '**/auth/v1/user', {
+      statusCode: 200,
+      body: {},
+    }).as('updateUser');
+
+    cy.intercept('POST', '**/auth/v1/logout', {
+      statusCode: 200,
+      body: {},
+    }).as('logout');
+
+    cy.visit('/auth/callback');
+
+    cy.get('input[type="password"]').eq(0).type('newpassword');
+    cy.get('input[type="password"]').eq(1).type('newpassword');
+    cy.get('button[type="submit"]').click();
+
+    cy.wait('@updateUser');
+    cy.contains('パスワードを更新しました').should('be.visible');
+    cy.get('a[href="/login"]').should('be.visible');
+  });
+});

--- a/src/pages/PasswordResetCallback.jsx
+++ b/src/pages/PasswordResetCallback.jsx
@@ -51,7 +51,7 @@ export default function PasswordResetCallback() {
         <h2>パスワード更新</h2>
         <div className='card'>
           <p>パスワードを更新しました。ログインし直してください。</p>
-          <a href='/'>ログイン画面へ</a>
+          <a href='/login'>ログイン画面へ</a>
         </div>
       </section>
     );


### PR DESCRIPTION
## Summary
- link password reset success page to `/login`
- add Cypress e2e test for password reset callback

## Testing
- `pnpm lint`
- `npx cypress run --spec cypress/e2e/callback.cy.js,cypress/e2e/forgot.cy.js` *(fails: No version of Cypress is installed)*

------
https://chatgpt.com/codex/tasks/task_e_689be292b1a4832e9473ca6de07bfaaf