### PR TITLE
Refresh session after unlinking identity

### DIFF
--- a/src/components/AccountLink.jsx
+++ b/src/components/AccountLink.jsx
@@ -103,7 +103,8 @@ export default function AccountLink({ user }) {
       if (error) throw error;
 
       toast.success('アカウント連携を解除しました');
-      await fetchIdentities(); // リストを更新
+      await supabase.auth.refreshSession();
+      await fetchIdentities();
     } catch (error) {
       console.error('Unlink account error:', error);
       toast.error(`連携解除に失敗しました: ${error.message}`);


### PR DESCRIPTION
## Summary
- refresh auth session after unlinking identity and reload identities

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689d35c689b4832e97016d090bbed3a3