### PR TITLE
Persist DB-loaded data to localStorage

### DIFF
--- a/src/state/StoreContextWithDB.jsx
+++ b/src/state/StoreContextWithDB.jsx
@@ -81,12 +81,21 @@ function reducer(state, action) {
     
     case 'loadFromDatabase': {
       const { transactions = [], rules = [], profile = null } = action.payload;
+      const normalizedTransactions = transactions.map(tx => ({
+        ...tx,
+        kind: tx.kind || (tx.amount < 0 ? 'expense' : 'income'),
+      }));
+      localStorage.setItem('lm_rules_v1', JSON.stringify(rules));
+      localStorage.setItem(
+        'lm_tx_v1',
+        JSON.stringify({
+          transactions: normalizedTransactions,
+          lastImportAt: state.lastImportAt,
+        })
+      );
       return {
         ...state,
-        transactions: transactions.map(tx => ({
-          ...tx,
-          kind: tx.kind || (tx.amount < 0 ? 'expense' : 'income'),
-        })),
+        transactions: normalizedTransactions,
         rules,
         profile,
         syncStatus: 'synced',


### PR DESCRIPTION
## Summary
- Save transactions and rules to localStorage when loading from database
- Keep synced data available after page reload

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689d3c84d294832ea8688865d1e75fbb