### PR TITLE
feat: sync deletions without waiting for state update

### DIFF
--- a/src/pages/DataCleanup.jsx
+++ b/src/pages/DataCleanup.jsx
@@ -115,17 +115,17 @@ export default function DataCleanup() {
     try {
       // ローカルストレージから削除
       const remainingTransactions = state.transactions.filter(tx => !selectedIds.has(tx.id));
-      
+
       // ストアを更新
       dispatch({
         type: 'importTransactions',
         payload: remainingTransactions,
         append: false
       });
-      
-      // データベースと同期
+
+      // データベースと同期（stateの更新を待たずに送信）
       if (session?.user?.id) {
-        await syncWithDatabase();
+        await syncWithDatabase(remainingTransactions);
       }
       
       toast.success(`${selectedIds.size}件のデータを削除しました`);


### PR DESCRIPTION
## Summary
- allow `syncWithDatabase` to accept an optional transaction list
- sync duplicate deletions using the freshly computed transactions without waiting for React state

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689da17bff3c832eb0bdbef30eba52b6