### PR TITLE
BarByMonthグラフの横スクロール対応

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -354,15 +354,17 @@ function Dashboard({
       </div>
 
       <div className="card">
-        <BarByMonth
-          transactions={transactions}
-          period={period}
-          yenUnit={yenUnit}
-          lockColors={lockColors}
-          hideOthers={hideOthers}
-          kind={kind}
-          height={350}
-        />
+        <div style={{ overflowX: 'auto' }}>
+          <BarByMonth
+            transactions={transactions}
+            period={period}
+            yenUnit={yenUnit}
+            lockColors={lockColors}
+            hideOthers={hideOthers}
+            kind={kind}
+            height={350}
+          />
+        </div>
       </div>
 
       <div className="card">

--- a/src/pages/Monthly.jsx
+++ b/src/pages/Monthly.jsx
@@ -59,15 +59,17 @@ export default function Monthly({
             <span className='ml-2'>カード支払いを除外して分析</span>
           </label>
         </div>
-        <BarByMonth
-          transactions={filteredTransactions}
-          period={period}
-          yenUnit={yenUnit}
-          lockColors={lockColors}
-          hideOthers={hideOthers}
-          kind={kind}
-          height={350}
-        />
+        <div style={{ overflowX: 'auto' }}>
+          <BarByMonth
+            transactions={filteredTransactions}
+            period={period}
+            yenUnit={yenUnit}
+            lockColors={lockColors}
+            hideOthers={hideOthers}
+            kind={kind}
+            height={350}
+          />
+        </div>
         <div style={{ marginTop: 16 }}>
           {months.length > 0 && (
             <div style={{ marginBottom: 8 }}>


### PR DESCRIPTION
## Summary
- Dashboardと月次分析ページのBarByMonthを横スクロールできるようにラッパーdivを追加

## Testing
- `pnpm lint`
- `pnpm build`
- `pnpm dev`

------
https://chatgpt.com/codex/tasks/task_e_689da6c717a4832eab0513df87615f48