### PR TITLE
Avoid applying rules in setRules cases

### DIFF
--- a/src/state/StoreContext.jsx
+++ b/src/state/StoreContext.jsx
@@ -102,17 +102,15 @@ function reducer(state, action) {
     }
     case 'setRules': {
       const rules = action.payload || [];
-      const transactions = applyRulesToTransactions(state.transactions, rules);
-      const updatedState = { ...state, transactions, rules };
-      localStorage.setItem('lm_rules_v1', JSON.stringify(updatedState.rules));
+      localStorage.setItem('lm_rules_v1', JSON.stringify(rules));
       localStorage.setItem(
         'lm_tx_v1',
         JSON.stringify({
-          transactions: updatedState.transactions,
+          transactions: state.transactions,
           lastImportAt: state.lastImportAt,
         })
       );
-      return updatedState;
+      return { ...state, rules };
     }
     case 'applyRules': {
       const transactions = applyRulesToTransactions(state.transactions, state.rules);

--- a/src/state/StoreContextWithDB.jsx
+++ b/src/state/StoreContextWithDB.jsx
@@ -155,17 +155,15 @@ function reducer(state, action) {
         ...rule,
         id: rule.id || crypto.randomUUID(),
       }));
-      const transactions = applyRulesToTransactions(state.transactions, rules);
-      const updatedState = { ...state, transactions, rules, syncStatus: 'pending' };
-      localStorage.setItem('lm_rules_v1', JSON.stringify(updatedState.rules));
+      localStorage.setItem('lm_rules_v1', JSON.stringify(rules));
       localStorage.setItem(
         'lm_tx_v1',
         JSON.stringify({
-          transactions: updatedState.transactions,
+          transactions: state.transactions,
           lastImportAt: state.lastImportAt,
         })
       );
-      return updatedState;
+      return { ...state, rules, syncStatus: 'pending' };
     }
     
     case 'applyRules': {


### PR DESCRIPTION
## Summary
- Stop reapplying rules when updating rule list
- Preserve existing transactions when saving after rules update

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_689db553bf34832ea70c56f028d75770