### PR TITLE
ルール変更後のデータ反映手順をコメントとドキュメントに追記

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -27,6 +27,7 @@ npm run dev
 ## できること
 - 複数CSVのドラッグ＆ドロップ取り込み（SJIS/UTF-8、自動ヘッダースキップ）
 - ルール管理（保存は localStorage）
+  - ルールを追加・変更した後はルール画面の「データ反映」ボタンを押して取引データに反映させます
 - 可視化（Recharts）
 - Excel/CSV 出力（xlsx/papaparse）
 

--- a/src/OthersTable.jsx
+++ b/src/OthersTable.jsx
@@ -88,9 +88,9 @@ function OthersRow({ row, onAdd, isMobile, yenUnit }) {
  *   yenUnit: 'yen' | 'man';
  * }} props
  * `addRule` は新しいルールを上位コンポーネントで保存するためのコールバック。
- * 利用側では `dispatch({ type: 'setRules', payload: [...rules, newRule] })`
- * および `dispatch({ type: 'applyRules' })` を実行する想定。
- */
+ * 利用側では `dispatch({ type: 'setRules', payload: [...rules, newRule] })` を実行した後、
+ * ルール画面の「データ反映」ボタンを押して取引に反映してください。
+*/
 export default function OthersTable({ rows, addRule, isMobile, kind, yenUnit }) {
   return (
     <table style={{ width: '100%', borderCollapse: 'collapse' }}>

--- a/src/pages/Others.jsx
+++ b/src/pages/Others.jsx
@@ -40,7 +40,7 @@ export default function Others({ yenUnit }) {
   const addRule = newRule => {
     console.log('addRule called with:', newRule);
     console.log('Current rules:', state.rules);
-    // setRulesアクションが自動的にルールを適用するため、applyRulesは不要
+    // ルールを追加・変更した後はルール画面の「データ反映」ボタンを押して取引に反映してください
     dispatch({ type: 'setRules', payload: [...state.rules, newRule] });
     console.log('Rule added and applied');
   };

--- a/src/pages/Transactions.jsx
+++ b/src/pages/Transactions.jsx
@@ -91,7 +91,7 @@ export default function Transactions() {
   const saveRule = () => {
     const rules = state.rules || [];
     const updatedRules = [...rules, newRule];
-    // setRulesアクションが自動的にルールを適用するため、applyRulesは不要
+    // ルールを追加・変更した後はルール画面の「データ反映」ボタンを押して取引に反映してください
     dispatch({ type: 'setRules', payload: updatedRules });
     setShowRuleModal(false);
     setSelectedTx(null);


### PR DESCRIPTION
## 概要
- ルール追加時にデータ反映ボタンを押す旨のコメントを各コンポーネントへ追記
- README にルール変更後の手動反映手順を追記

## テスト
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689db559a3c4832eb759cb267d88f919