### PR TITLE
ドロワーメニューに表示名を追加

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -530,6 +530,11 @@ body {
   z-index:101;
 }
 
+.user-display {
+  font-weight:600;
+  margin-bottom:.75rem;
+}
+
 .drawer-panel h4 {
   margin:.75rem 0 .25rem;
   color:var(--muted);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -458,16 +458,6 @@ function Dashboard({
         </div>
         <div className='title'>
           <span>家計簿カテゴリ管理</span>
-          {state.profile?.display_name && (
-            <span style={{ 
-              fontSize: '0.8em', 
-              marginLeft: '8px',
-              color: '#6b7280',
-              fontWeight: 'normal'
-            }}>
-              ({state.profile.display_name})
-            </span>
-          )}
         </div>
         <button
           ref={burgerRef}
@@ -491,6 +481,9 @@ function Dashboard({
           className='drawer-panel'
           onClick={e => e.stopPropagation()}
         >
+          {state.profile?.display_name && (
+            <div className='user-display'>{state.profile.display_name}</div>
+          )}
           <h4>メイン</h4>
           {NAV.main.map(i => (
             <NavItem key={i.key} active={page === i.key} onClick={() => go(i.key)}>{i.label}</NavItem>


### PR DESCRIPTION
## Summary
- ヘッダーから表示名を削除
- ドロワーメニュー上部に表示名を追加し `.user-display` でスタイル設定

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689dce3e7940832e95c25f92af45ba0a