### PR TITLE
月次分析画面のUI調整

### DIFF
--- a/src/pages/Monthly.jsx
+++ b/src/pages/Monthly.jsx
@@ -59,6 +59,37 @@ export default function Monthly({
     <section>
       <h1 className="text-2xl font-bold mb-4">月次分析</h1>
       <div className='card'>
+        {months.length > 0 && (
+          <div style={{ marginBottom: 16 }}>
+            <label style={{ marginRight: 8 }}>月選択:</label>
+            <select
+              value={selectedMonth}
+              onChange={(e) => setSelectedMonth(e.target.value)}
+              style={{ padding: '4px 8px', borderRadius: '4px', border: '1px solid #ddd' }}
+            >
+              {months.map((m) => (
+                <option key={m} value={m}>
+                  {m}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        <div style={{ marginBottom: 24 }}>
+          <h3 style={{ fontSize: '1.1rem', fontWeight: 'bold', marginBottom: 12 }}>
+            {selectedMonth ? `${selectedMonth} カテゴリー別内訳` : 'カテゴリー別内訳'}
+          </h3>
+          <PieByCategory
+            transactions={monthTxs}
+            period="all"
+            yenUnit={yenUnit}
+            lockColors={lockColors}
+            hideOthers={hideOthers}
+            kind={kind}
+          />
+        </div>
+
         <div style={{ marginBottom: 16, display: 'flex', gap: 16, flexWrap: 'wrap', alignItems: 'center' }}>
           <label style={{ display: 'flex', alignItems: 'center' }}>
             <input
@@ -76,38 +107,8 @@ export default function Monthly({
             />
             <span className='ml-2'>家賃を除外して分析</span>
           </label>
-          {months.length > 0 && (
-            <div style={{ marginLeft: 'auto' }}>
-              <label style={{ marginRight: 8 }}>月選択:</label>
-              <select
-                value={selectedMonth}
-                onChange={(e) => setSelectedMonth(e.target.value)}
-                style={{ padding: '4px 8px', borderRadius: '4px', border: '1px solid #ddd' }}
-              >
-                {months.map((m) => (
-                  <option key={m} value={m}>
-                    {m}
-                  </option>
-                ))}
-              </select>
-            </div>
-          )}
         </div>
-        
-        <div style={{ marginBottom: 24 }}>
-          <h3 style={{ fontSize: '1.1rem', fontWeight: 'bold', marginBottom: 12 }}>
-            {selectedMonth ? `${selectedMonth} カテゴリー別内訳` : 'カテゴリー別内訳'}
-          </h3>
-          <PieByCategory
-            transactions={monthTxs}
-            period="all"
-            yenUnit={yenUnit}
-            lockColors={lockColors}
-            hideOthers={hideOthers}
-            kind={kind}
-          />
-        </div>
-        
+
         <div ref={chartContainerRef} style={{ position: 'relative' }}>
           <h3 style={{ fontSize: '1.1rem', fontWeight: 'bold', marginBottom: 12 }}>月次推移</h3>
           <BarByMonth

--- a/src/pages/MonthlyAnalysis.jsx
+++ b/src/pages/MonthlyAnalysis.jsx
@@ -47,6 +47,41 @@ export default function MonthlyAnalysis({
   return (
     <section>
       <div className='card'>
+        {months.length > 0 && (
+          <div style={{ marginBottom: 16 }}>
+            <select value={selectedMonth} onChange={e => setSelectedMonth(e.target.value)}>
+              {months.map(m => (
+                <option key={m} value={m}>
+                  {m}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 16, marginBottom: 16 }}>
+          <div style={{ flex: 1, minWidth: 300 }}>
+            <h3 style={{ textAlign: 'center', marginBottom: 8 }}>支出</h3>
+            <PieByCategory
+              transactions={monthTxs}
+              period='all'
+              yenUnit={yenUnit}
+              lockColors={lockColors}
+              hideOthers={hideOthers}
+              kind='expense'
+            />
+          </div>
+          <div style={{ flex: 1, minWidth: 300 }}>
+            <h3 style={{ textAlign: 'center', marginBottom: 8 }}>収入</h3>
+            <PieByCategory
+              transactions={monthTxs}
+              period='all'
+              yenUnit={yenUnit}
+              lockColors={lockColors}
+              hideOthers={hideOthers}
+              kind='income'
+            />
+          </div>
+        </div>
         <div style={{ display: 'flex', flexWrap: 'wrap', gap: 16 }}>
           <div style={{ flex: 1, minWidth: 300 }}>
             <div style={{ overflowX: 'auto' }}>
@@ -82,41 +117,6 @@ export default function MonthlyAnalysis({
             onSelectMonth={setSelectedMonth}
             yenUnit={yenUnit}
           />
-          {months.length > 0 && (
-            <div style={{ marginTop: 8 }}>
-              <select value={selectedMonth} onChange={e => setSelectedMonth(e.target.value)}>
-                {months.map(m => (
-                  <option key={m} value={m}>
-                    {m}
-                  </option>
-                ))}
-              </select>
-            </div>
-          )}
-          <div style={{ display: 'flex', flexWrap: 'wrap', gap: 16, marginTop: 16 }}>
-            <div style={{ flex: 1, minWidth: 300 }}>
-              <h3 style={{ textAlign: 'center', marginBottom: 8 }}>支出</h3>
-              <PieByCategory
-                transactions={monthTxs}
-                period='all'
-                yenUnit={yenUnit}
-                lockColors={lockColors}
-                hideOthers={hideOthers}
-                kind='expense'
-              />
-            </div>
-            <div style={{ flex: 1, minWidth: 300 }}>
-              <h3 style={{ textAlign: 'center', marginBottom: 8 }}>収入</h3>
-              <PieByCategory
-                transactions={monthTxs}
-                period='all'
-                yenUnit={yenUnit}
-                lockColors={lockColors}
-                hideOthers={hideOthers}
-                kind='income'
-              />
-            </div>
-          </div>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- 月次分析ページの月選択と円グラフをカード上部に移動
- 月次比較ページでも同様に月選択と円グラフを先頭に配置

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_689dd275431c832e9920a620bca4da9d