### PR TITLE
feat: adjust BarByMonth layout for mobile

### DIFF
--- a/src/BarByMonth.jsx
+++ b/src/BarByMonth.jsx
@@ -74,7 +74,7 @@ export default function BarByMonth({
   lockColors,
   hideOthers,
   kind = 'expense',
-  height = 350,
+  height = 500,
 }) {
   const scrollRef = useRef(null);
   const [touchStart, setTouchStart] = useState(null);
@@ -141,7 +141,7 @@ export default function BarByMonth({
 
   const isMobile = typeof window !== 'undefined' && window.innerWidth < 768;
   // データの数に応じてグラフの最小幅を計算（1項目あたり最低80px）
-  const minBarWidth = Math.max(dataWithColors.length * 80, 350);
+  const minBarWidth = Math.max(dataWithColors.length * 80, 500);
   const chartWidth = isMobile ? Math.max(minBarWidth, width) : '100%';
   
   // タッチイベントのハンドラー


### PR DESCRIPTION
## Summary
- increase default height to 500 to allow larger chart
- widen bar chart for mobile by raising min width to 500

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689ddba927a4832e9d043b3c875bafa4