### PR TITLE
Sort pie chart items by value and place others last

### DIFF
--- a/src/PieByCategory.jsx
+++ b/src/PieByCategory.jsx
@@ -117,6 +117,11 @@ export default function PieByCategory({
   if (!hideOthers && othersValue > 0) {
     items.push({ name: 'その他', value: othersValue });
   }
+  items.sort((a, b) => {
+    if (a.name === 'その他') return 1;
+    if (b.name === 'その他') return -1;
+    return b.value - a.value;
+  });
 
   const colorMap = useRef({});
   const dataWithColors = useMemo(() => {


### PR DESCRIPTION
## Summary
- sort pie chart items in descending order of value
- keep "その他" as the final legend entry

## Testing
- `pnpm lint`
- `node -e "const items=[{name:'Food',value:50},{name:'その他',value:100},{name:'Rent',value:200}];items.sort((a,b)=>{if(a.name==='その他')return 1;if(b.name==='その他')return -1;return b.value-a.value;});console.log(items);"`


------
https://chatgpt.com/codex/tasks/task_e_689de280a818832ea76d87bf14ba6d03