### PR TITLE
feat: exclude card payments by default

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -290,7 +290,7 @@ function Dashboard({
   onToggleOthers,
   onKindChange,
 }) {
-  const [excludeCardPayments, setExcludeCardPayments] = useState(false);
+  const [excludeCardPayments, setExcludeCardPayments] = useState(true);
   const [excludeRent, setExcludeRent] = useState(false);
   
   // カード支払いと家賃を除外するかどうかでフィルタリング

--- a/src/pages/Monthly.jsx
+++ b/src/pages/Monthly.jsx
@@ -10,7 +10,7 @@ export default function Monthly({
   hideOthers,
   kind,
 }) {
-  const [excludeCardPayments, setExcludeCardPayments] = useState(false);
+  const [excludeCardPayments, setExcludeCardPayments] = useState(true);
   const [excludeRent, setExcludeRent] = useState(false);
   const chartContainerRef = useRef(null);
   // カード支払いと家賃を除外するかどうかでフィルタリング

--- a/src/pages/Transactions.jsx
+++ b/src/pages/Transactions.jsx
@@ -22,7 +22,7 @@ export default function Transactions() {
   const [showRuleModal, setShowRuleModal] = useState(false);
   const [selectedTx, setSelectedTx] = useState(null);
   const [editedCategories, setEditedCategories] = useState({});
-  const [excludeCardPayments, setExcludeCardPayments] = useState(false);
+  const [excludeCardPayments, setExcludeCardPayments] = useState(true);
   const [showUnclassifiedOnly, setShowUnclassifiedOnly] = useState(false);
   const [ruleAppliedMessage, setRuleAppliedMessage] = useState('');
   const [newRule, setNewRule] = useState({

--- a/src/pages/Yearly.jsx
+++ b/src/pages/Yearly.jsx
@@ -9,7 +9,7 @@ export default function Yearly({
   hideOthers,
   kind,
 }) {
-  const [excludeCardPayments, setExcludeCardPayments] = useState(false);
+  const [excludeCardPayments, setExcludeCardPayments] = useState(true);
   const [excludeRent, setExcludeRent] = useState(false);
 
   // カード支払いと家賃を除外するかどうかでフィルタリング


### PR DESCRIPTION
## Summary
- enable card payment exclusion by default across dashboard and analytics pages
- start transaction list with card payment filter enabled

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689de1350a70832ea48b1e90ed381eb4