### PR TITLE
Add transaction metadata columns

### DIFF
--- a/src/services/database.js
+++ b/src/services/database.js
@@ -75,21 +75,22 @@ export const dbService = {
         const memoText = tx.memo || tx.メモ || '';
         const hashString = `${userId}_${dateValue}_${amount}_${descText}_${detailText}_${memoText}_${tx.id || Math.random()}`;
         const hash = tx.hash || hashString;
-        
+        const excludeFromTotals =
+          tx.excludeFromTotals ?? tx.exclude_from_totals ?? false;
+
         return {
-          id: tx.id || tx.ID || crypto.randomUUID(),  // CSVのIDフィールドも考慮
+          id: tx.id || tx.ID || crypto.randomUUID(), // CSVのIDフィールドも考慮
           user_id: userId,
-          date: dateValue,  // timestampz型
-          occurred_on: dateValue,  // date型（必須）
+          date: dateValue, // DATE型
+          occurred_on: dateValue, // DATE型
           amount: amount !== undefined && !isNaN(amount) ? amount : 0,
-          category: tx.category || tx.カテゴリ || '',  // text型
-          description: tx.description || tx.説明 || '',  // text型
-          detail: tx.detail || tx.詳細 || '',  // text型
-          memo: tx.memo || tx.メモ || '',  // text型
-          kind: tx.kind || tx.種別 || (amount < 0 ? 'expense' : 'income'),  // text型
-          hash: hash,  // text型（テーブルに存在）
-          exclude_from_totals: tx.excludeFromTotals || false,  // boolean型（集計対象外フラグ）
-          created_at: tx.created_at || new Date().toISOString()  // timestampz型
+          category: tx.category || tx.カテゴリ || '', // text型
+          description: tx.description || tx.説明 || '', // text型
+          detail: tx.detail || tx.詳細 || '', // text型
+          memo: tx.memo || tx.メモ || '', // text型
+          kind: tx.kind || tx.種別 || (amount < 0 ? 'expense' : 'income'), // text型
+          hash,
+          exclude_from_totals: excludeFromTotals // boolean型（集計対象外フラグ）
         };
       });
 

--- a/supabase/migrations/20250815_add_transactions_columns.sql
+++ b/supabase/migrations/20250815_add_transactions_columns.sql
@@ -1,0 +1,21 @@
+-- Add new columns to transactions table
+ALTER TABLE transactions
+  ADD COLUMN IF NOT EXISTS occurred_on DATE,
+  ADD COLUMN IF NOT EXISTS hash TEXT,
+  ADD COLUMN IF NOT EXISTS exclude_from_totals BOOLEAN DEFAULT false;
+
+-- Populate new columns for existing rows
+UPDATE transactions
+SET occurred_on = date
+WHERE occurred_on IS NULL;
+
+UPDATE transactions
+SET hash = md5(
+  user_id::text || '_' || date::text || '_' || amount::text || '_' ||
+  COALESCE(description, '') || '_' || COALESCE(detail, '') || '_' || COALESCE(memo, '')
+)
+WHERE hash IS NULL;
+
+UPDATE transactions
+SET exclude_from_totals = false
+WHERE exclude_from_totals IS NULL;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -12,6 +12,9 @@ CREATE TABLE IF NOT EXISTS transactions (
   detail TEXT,
   memo TEXT,
   kind VARCHAR(20) CHECK (kind IN ('income', 'expense')),
+  occurred_on DATE,
+  hash TEXT,
+  exclude_from_totals BOOLEAN DEFAULT false,
   created_at TIMESTAMPTZ DEFAULT NOW(),
   updated_at TIMESTAMPTZ DEFAULT NOW(),
   PRIMARY KEY (id, user_id)


### PR DESCRIPTION
## Summary
- add occurred_on, hash, exclude_from_totals columns to transactions schema
- migrate existing transaction records
- update database mapping to include new fields

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689ed167ff90832eba90a06329f29aee