### PR TITLE
金額単位切替ボタンの選択状態を色で強調

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -483,7 +483,7 @@ function Dashboard({
                 variant={yenUnit === 'yen' ? 'default' : 'outline'}
                 size="sm"
                 onClick={() => onToggleUnit()}
-                className="flex-1"
+                className={`flex-1 ${yenUnit === 'yen' ? 'bg-blue-500 hover:bg-blue-600 text-white border-blue-500' : ''}`}
               >
                 円表示
               </Button>
@@ -491,7 +491,7 @@ function Dashboard({
                 variant={yenUnit === 'man' ? 'default' : 'outline'}
                 size="sm"
                 onClick={() => onToggleUnit()}
-                className="flex-1"
+                className={`flex-1 ${yenUnit === 'man' ? 'bg-blue-500 hover:bg-blue-600 text-white border-blue-500' : ''}`}
               >
                 万円表示
               </Button>

--- a/src/pages/Prefs.jsx
+++ b/src/pages/Prefs.jsx
@@ -142,7 +142,7 @@ export default function Prefs() {
                   variant={yenUnit === 'yen' ? 'default' : 'outline'}
                   size="sm"
                   onClick={() => setYenUnit('yen')}
-                  className="flex-1"
+                  className={`flex-1 ${yenUnit === 'yen' ? 'bg-blue-500 hover:bg-blue-600 text-white border-blue-500' : ''}`}
                 >
                   <DollarSign className="w-4 h-4 mr-2" />
                   円表示
@@ -151,7 +151,7 @@ export default function Prefs() {
                   variant={yenUnit === 'man' ? 'default' : 'outline'}
                   size="sm"
                   onClick={() => setYenUnit('man')}
-                  className="flex-1"
+                  className={`flex-1 ${yenUnit === 'man' ? 'bg-blue-500 hover:bg-blue-600 text-white border-blue-500' : ''}`}
                 >
                   <DollarSign className="w-4 h-4 mr-2" />
                   万円表示


### PR DESCRIPTION
## 概要
- 円表示/万円表示の切替ボタンで選択中の単位を青色で強調表示

## テスト
- `pnpm lint` : ESLint 設定ファイル不足エラー

------
https://chatgpt.com/codex/tasks/task_e_689ed647c390832ebc7eda2b52a33116