### PR TITLE
Show fallback when PieByCategory has no data

### DIFF
--- a/src/PieByCategory.jsx
+++ b/src/PieByCategory.jsx
@@ -114,7 +114,9 @@ export default function PieByCategory({
       items.push({ name, value });
     }
   });
-  if (!hideOthers && othersValue > 0) {
+  if (items.length === 0 && othersValue > 0) {
+    items.push({ name: 'その他', value: othersValue });
+  } else if (!hideOthers && othersValue > 0) {
     items.push({ name: 'その他', value: othersValue });
   }
   items.sort((a, b) => {
@@ -134,6 +136,10 @@ export default function PieByCategory({
     });
     return items.map((d) => ({ ...d, fill: colorMap.current[d.name] }));
   }, [items, lockColors]);
+
+  if (items.length === 0) {
+    return <p>データがありません</p>;
+  }
 
   const formatValue = (v) => formatAmount(v, yenUnit);
   const tooltipFormatter = (v, name) => [formatValue(v), name];


### PR DESCRIPTION
## Summary
- Show その他 slice when filtered items are empty but othersValue exists
- Display a placeholder message when there are no items to chart

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689ed8193cb8832e8198d43708b45fc3