### PR TITLE
refactor: simplify MonthlyAnalysis

### DIFF
--- a/src/pages/MonthlyAnalysis.jsx
+++ b/src/pages/MonthlyAnalysis.jsx
@@ -1,4 +1,3 @@
-import { useMemo, useState } from 'react';
 import BarByMonth from '../BarByMonth.jsx';
 
 export default function MonthlyAnalysis({
@@ -8,46 +7,13 @@ export default function MonthlyAnalysis({
   lockColors,
   hideOthers,
 }) {
-  const [excludeCardPayments, setExcludeCardPayments] = useState(false);
-  const [excludeRent, setExcludeRent] = useState(false);
-  const filteredTransactions = useMemo(() => {
-    let filtered = transactions;
-    if (excludeCardPayments) {
-      filtered = filtered.filter(
-        tx => tx.category !== 'カード支払い' && tx.category !== 'カード払い',
-      );
-    }
-    if (excludeRent) {
-      filtered = filtered.filter(tx => tx.category !== '家賃');
-    }
-    return filtered;
-  }, [transactions, excludeCardPayments, excludeRent]);
-
   return (
     <section>
       {/* 月次推移グラフ */}
       <div className='card' style={{ marginBottom: 16 }}>
         <h3 style={{ marginBottom: 16 }}>月次推移</h3>
-        <div style={{ marginBottom: 16, display: 'flex', gap: 16, flexWrap: 'wrap', alignItems: 'center' }}>
-          <label style={{ display: 'flex', alignItems: 'center' }}>
-            <input
-              type='checkbox'
-              checked={excludeCardPayments}
-              onChange={e => setExcludeCardPayments(e.target.checked)}
-            />
-            <span className='ml-2'>カード支払いを除外</span>
-          </label>
-          <label style={{ display: 'flex', alignItems: 'center' }}>
-            <input
-              type='checkbox'
-              checked={excludeRent}
-              onChange={e => setExcludeRent(e.target.checked)}
-            />
-            <span className='ml-2'>家賃を除外</span>
-          </label>
-        </div>
         <BarByMonth
-          transactions={filteredTransactions}
+          transactions={transactions}
           period={period}
           yenUnit={yenUnit}
           lockColors={lockColors}


### PR DESCRIPTION
## Summary
- remove state and filtering logic from MonthlyAnalysis page
- drop card payment and rent exclusion checkboxes
- pass raw transactions to BarByMonth

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_689ed8fb4cc0832eb47ca4626914b63f