### PR TITLE
Add date range filter for transaction loading

### DIFF
--- a/src/pages/Transactions.jsx
+++ b/src/pages/Transactions.jsx
@@ -19,7 +19,7 @@ import {
 /** @typedef {import('../types').Rule} Rule */
 
 export default function Transactions() {
-  const { state, dispatch } = useStore();
+  const { state, dispatch, loadFromDatabase } = useStore();
   /** @type {Transaction[]} */
   const txs = state.transactions;
   const categories = state.categories;
@@ -103,6 +103,15 @@ useEffect(() => {
   keyword, minAmount, maxAmount, type,
   excludeCardPayments, showUnclassifiedOnly,
 ]);
+
+useEffect(() => {
+  if (loadFromDatabase) {
+    loadFromDatabase({
+      startDate: startDate || undefined,
+      endDate: endDate || undefined,
+    });
+  }
+}, [startDate, endDate, loadFromDatabase]);
 
   const pageSize = 50;
   const totalPages = Math.max(1, Math.ceil(filtered.length / pageSize));

--- a/src/services/database.js
+++ b/src/services/database.js
@@ -125,18 +125,26 @@ export const dbService = {
     }
   },
 
-  async loadTransactions(userId) {
+  async loadTransactions(userId, { startDate, endDate } = {}) {
     if (!supabase) {
       return { success: false, error: 'Supabase not initialized' };
     }
-    
+
     try {
-      const { data, error } = await supabase
+      let query = supabase
         .from('transactions')
         .select('*')
-        .eq('user_id', userId)
-        .order('date', { ascending: false });
-      
+        .eq('user_id', userId);
+
+      if (startDate) {
+        query = query.gte('date', startDate);
+      }
+      if (endDate) {
+        query = query.lte('date', endDate);
+      }
+
+      const { data, error } = await query.order('date', { ascending: false });
+
       if (error) throw error;
       return { success: true, data };
     } catch (error) {

--- a/src/state/StoreContextWithDB.jsx
+++ b/src/state/StoreContextWithDB.jsx
@@ -382,14 +382,14 @@ export function StoreProvider({ children }) {
     [session, state.transactions, state.rules]
   );
 
-  const loadFromDatabase = useCallback(async () => {
+  const loadFromDatabase = useCallback(async ({ startDate, endDate } = {}) => {
     if (!session?.user?.id) return;
-    
+
     dispatch({ type: 'setSyncStatus', payload: 'loading' });
-    
+
     try {
       const [txResult, rulesResult, profileResult] = await Promise.all([
-        dbService.loadTransactions(session.user.id),
+        dbService.loadTransactions(session.user.id, { startDate, endDate }),
         dbService.loadRules(session.user.id),
         dbService.loadProfile(session.user.id),
       ]);


### PR DESCRIPTION
## Summary
- expand loadTransactions to accept start/end dates and add Supabase filters
- pass date range from context and Transactions page

## Testing
- `pnpm run test` *(missing script: test)*

------
https://chatgpt.com/codex/tasks/task_e_689ed907c520832ead2db7cde68b2ff4