### PR TITLE
fix: replace dollar icon with yen

### DIFF
--- a/src/pages/Monthly.jsx
+++ b/src/pages/Monthly.jsx
@@ -7,7 +7,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { TrendingUp, TrendingDown, Calendar, Filter, X, DollarSign, FileText, BarChart3 } from 'lucide-react';
+import { TrendingUp, TrendingDown, Calendar, Filter, X, JapaneseYen, FileText, BarChart3 } from 'lucide-react';
 import { LineChart, Line, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
 import { formatAmount } from '../utils/currency.js';
 
@@ -355,7 +355,7 @@ export default function Monthly({
           <Card>
             <CardHeader>
               <CardTitle className="text-lg flex items-center gap-2">
-                <DollarSign className="w-4 h-4" />
+                <JapaneseYen className="w-4 h-4" />
                 月次サマリー
               </CardTitle>
             </CardHeader>

--- a/src/pages/Prefs.jsx
+++ b/src/pages/Prefs.jsx
@@ -8,10 +8,10 @@ import { Badge } from '@/components/ui/badge';
 import { 
   Settings, 
   Download, 
-  Upload, 
-  Trash2, 
+  Upload,
+  Trash2,
   Filter,
-  DollarSign,
+  JapaneseYen,
   TrendingUp,
   TrendingDown,
   AlertTriangle
@@ -144,7 +144,7 @@ export default function Prefs() {
                   onClick={() => setYenUnit('yen')}
                   className={`flex-1 ${yenUnit === 'yen' ? 'bg-blue-500 hover:bg-blue-600 text-white border-blue-500' : ''}`}
                 >
-                  <DollarSign className="w-4 h-4 mr-2" />
+                  <JapaneseYen className="w-4 h-4 mr-2" />
                   円表示
                 </Button>
                 <Button
@@ -153,7 +153,7 @@ export default function Prefs() {
                   onClick={() => setYenUnit('man')}
                   className={`flex-1 ${yenUnit === 'man' ? 'bg-blue-500 hover:bg-blue-600 text-white border-blue-500' : ''}`}
                 >
-                  <DollarSign className="w-4 h-4 mr-2" />
+                  <JapaneseYen className="w-4 h-4 mr-2" />
                   万円表示
                 </Button>
               </div>

--- a/src/pages/Transactions.jsx
+++ b/src/pages/Transactions.jsx
@@ -13,7 +13,7 @@ import { DEFAULT_CATEGORIES } from '../defaultCategories.js';
 import { 
   Search, Filter, Download, FileSpreadsheet, Plus, Save, 
   RefreshCw, X, ChevronLeft, ChevronRight, Calendar,
-  DollarSign, Tag, FileText, Settings, Trash2
+  JapaneseYen, Tag, FileText, Settings, Trash2
 } from 'lucide-react';
 /** @typedef {import('../types').Transaction} Transaction */
 /** @typedef {import('../types').Rule} Rule */
@@ -365,7 +365,7 @@ useEffect(() => {
               {/* 金額範囲 */}
               <div className="space-y-2">
                 <Label htmlFor="min-amount" className="text-sm font-medium flex items-center gap-1">
-                  <DollarSign className="w-3 h-3" />
+                  <JapaneseYen className="w-3 h-3" />
                   最小金額
                 </Label>
                 <Input
@@ -379,7 +379,7 @@ useEffect(() => {
               
               <div className="space-y-2">
                 <Label htmlFor="max-amount" className="text-sm font-medium flex items-center gap-1">
-                  <DollarSign className="w-3 h-3" />
+                  <JapaneseYen className="w-3 h-3" />
                   最大金額
                 </Label>
                 <Input
@@ -462,7 +462,7 @@ useEffect(() => {
                       カテゴリ
                     </th>
                     <th className="text-left p-3 font-semibold text-gray-700 whitespace-nowrap">
-                      <DollarSign className="w-4 h-4 inline mr-1" />
+                      <JapaneseYen className="w-4 h-4 inline mr-1" />
                       金額
                     </th>
                     <th className="text-left p-3 font-semibold text-gray-700 min-w-[150px]">


### PR DESCRIPTION
## Summary
- replace `DollarSign` icon with `JapaneseYen` for yen display on Prefs, Monthly, Transactions pages

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689ed9c608dc832e8b65d29bfe9f6f3c