### PR TITLE
feat: emphasize zero line in charts

### DIFF
--- a/src/BalanceChart.jsx
+++ b/src/BalanceChart.jsx
@@ -65,7 +65,7 @@ export default function BalanceChart({ transactions, period, yenUnit }) {
             <CartesianGrid strokeDasharray='3 3' />
             <XAxis dataKey='month' />
             <YAxis domain={domain} tickFormatter={v => formatAmount(v, yenUnit)} />
-            <ReferenceLine y={0} stroke='#000' strokeWidth={2} />
+            <ReferenceLine y={0} stroke='#000' strokeWidth={4} />
             <Tooltip formatter={tooltipFormatter} />
             <Bar dataKey='income' fill='#34d399' name='収入' />
             <Bar dataKey='expense' fill='#f87171' name='支出' />

--- a/src/NetBalanceLineChart.jsx
+++ b/src/NetBalanceLineChart.jsx
@@ -1,4 +1,4 @@
-import { LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid, ResponsiveContainer } from 'recharts';
+import { LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid, ResponsiveContainer, ReferenceLine } from 'recharts';
 import { convertAmount, formatAmount } from './utils/currency.js';
 
 export default function NetBalanceLineChart({ transactions, period, yenUnit }) {
@@ -30,6 +30,7 @@ export default function NetBalanceLineChart({ transactions, period, yenUnit }) {
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis dataKey="month" />
           <YAxis tickFormatter={tickFormatter} />
+          <ReferenceLine y={0} stroke="#000" strokeWidth={4} />
           <Tooltip formatter={tooltipFormatter} />
           <Line type="monotone" dataKey="diff" stroke="#8884d8" dot={{ r: 3 }} />
         </LineChart>


### PR DESCRIPTION
## Summary
- make zero reference line in balance chart thicker
- add bold zero reference line to net balance line chart

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689edb93d274832ea523db704be4eed2