### PR TITLE
feat: add size props for pie chart

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -118,6 +118,7 @@ export default function App() {
   const [syncing, setSyncing] = useState(false);
 
   const isAuthenticated = session || isLocalMode;
+  const isMobile = typeof window !== 'undefined' && window.innerWidth < 768;
 
   // 旧形式のfilterModeからcard/rentを除去
   useEffect(() => {
@@ -567,6 +568,8 @@ function Dashboard({
               lockColors={lockColors}
               hideOthers={hideOthers}
               kind={kind}
+              chartHeight={isMobile ? 300 : 250}
+              radius={isMobile ? '65%' : '80%'}
             />
           </CardContent>
         </Card>

--- a/src/PieByCategory.jsx
+++ b/src/PieByCategory.jsx
@@ -85,7 +85,12 @@ export default function PieByCategory({
   lockColors,
   hideOthers,
   kind = 'expense',
+  chartHeight,
+  radius,
 }) {
+  const isMobile = typeof window !== 'undefined' && window.innerWidth < 768;
+  chartHeight = chartHeight ?? 400;
+  radius = radius ?? (isMobile ? '75%' : '90%');
   const monthMap = {};
   const txs = transactions.filter((tx) => tx.kind === kind);
   txs.forEach((tx) => {
@@ -154,7 +159,6 @@ export default function PieByCategory({
   }));
 
   // カスタムラベル関数を追加
-  const isMobile = typeof window !== 'undefined' && window.innerWidth < 768;
   const renderCustomLabel = ({
     cx, cy, midAngle, innerRadius, outerRadius, value, index, percent
   }) => {
@@ -195,20 +199,20 @@ export default function PieByCategory({
       maxWidth: isMobile ? '100%' : 'none',
       margin: '0 auto'
     }}>
-      <ResponsiveContainer width="100%" height={isMobile ? 300 : 250}>
-        <RePieChart margin={{ 
-          top: isMobile ? 10 : 0, 
-          right: isMobile ? 10 : 30, 
-          bottom: isMobile ? 80 : 20, 
-          left: isMobile ? 10 : 30 
+      <ResponsiveContainer width="100%" height={chartHeight}>
+        <RePieChart margin={{
+          top: isMobile ? 10 : 0,
+          right: isMobile ? 10 : 30,
+          bottom: isMobile ? 80 : 20,
+          left: isMobile ? 10 : 30
         }}>
-          <Pie 
-            data={dataWithColors} 
-            dataKey="value" 
-            nameKey="name" 
+          <Pie
+            data={dataWithColors}
+            dataKey="value"
+            nameKey="name"
             label={renderCustomLabel}
             labelLine={false}
-            outerRadius={isMobile ? "65%" : "80%"}
+            outerRadius={radius}
             cx={isMobile ? "50%" : "50%"}
             cy={isMobile ? "45%" : "50%"}
           >

--- a/src/pages/Monthly.jsx
+++ b/src/pages/Monthly.jsx
@@ -132,6 +132,7 @@ export default function Monthly({
 
   const [selectedDay, setSelectedDay] = useState(null);
   const [showDetails, setShowDetails] = useState(false);
+  const isMobile = typeof window !== 'undefined' && window.innerWidth < 768;
 
   return (
     <div className="container mx-auto px-4 py-6 max-w-7xl">
@@ -280,6 +281,8 @@ export default function Monthly({
                 lockColors={lockColors}
                 hideOthers={hideOthers}
                 kind={kind}
+                chartHeight={isMobile ? 300 : 250}
+                radius={isMobile ? '65%' : '80%'}
               />
             </CardContent>
           </Card>

--- a/src/pages/Yearly.jsx
+++ b/src/pages/Yearly.jsx
@@ -41,6 +41,7 @@ export default function Yearly({
 
   const currentYear = new Date().getFullYear().toString();
   const currentYearData = yearlyStats.find(s => s.year === currentYear);
+  const isMobile = typeof window !== 'undefined' && window.innerWidth < 768;
 
   return (
     <div className="container mx-auto px-4 py-6 max-w-7xl">
@@ -112,6 +113,8 @@ export default function Yearly({
                     lockColors={lockColors}
                     hideOthers={hideOthers}
                     kind={kind}
+                    chartHeight={isMobile ? 300 : 250}
+                    radius={isMobile ? '65%' : '80%'}
                   />
                 </TabsContent>
                 <TabsContent value="monthly" className="mt-4">


### PR DESCRIPTION
## Summary
- allow passing chartHeight and radius to PieByCategory with sensible defaults
- wire Yearly, Monthly and App pages to pass pie chart size props

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689ede2fb2a4832ead0f549597259ffa