### PR TITLE
Add 3-month moving average line to monthly bar chart

### DIFF
--- a/src/BarByMonth.jsx
+++ b/src/BarByMonth.jsx
@@ -10,6 +10,7 @@ import {
   Legend,
   Cell,
   ReferenceLine,
+  Line,
 } from 'recharts';
 
 const BAR_COLORS = [
@@ -109,6 +110,15 @@ export default function BarByMonth({
     });
     return data.map((d) => ({ ...d, fill: colorMap.current[d.month] }));
   }, [data, lockColors]);
+
+  const dataWithMovingAvg = useMemo(() => {
+    return dataWithColors.map((d, idx, arr) => {
+      const start = Math.max(0, idx - 2);
+      const subset = arr.slice(start, idx + 1);
+      const avg = subset.reduce((sum, item) => sum + item.total, 0) / subset.length;
+      return { ...d, movingAvg: avg };
+    });
+  }, [dataWithColors]);
 
   const maxTotal = useMemo(
     () => Math.max(...dataWithColors.map(d => d.total), 0),
@@ -239,7 +249,7 @@ export default function BarByMonth({
         minWidth: isMobile ? minBarWidth : 'auto'
       }}>
         <ResponsiveContainer width='100%' height={height}>
-          <ReBarChart data={dataWithColors} margin={{ top: 8, right: isMobile ? 8 : 16, left: isMobile ? -10 : 0, bottom: 28 }}>
+          <ReBarChart data={dataWithMovingAvg} margin={{ top: 8, right: isMobile ? 8 : 16, left: isMobile ? -10 : 0, bottom: 28 }}>
           <XAxis
             dataKey="month"
             interval={0}
@@ -264,10 +274,11 @@ export default function BarByMonth({
             label={{ position: 'right', value: `平均: ${formatValue(average)}` }}
           />
           <Bar dataKey="total" name="合計">
-            {dataWithColors.map((entry, idx) => (
+            {dataWithMovingAvg.map((entry, idx) => (
               <Cell key={`cell-${idx}`} fill={entry.fill} />
             ))}
           </Bar>
+          <Line type="monotone" dataKey="movingAvg" name="3ヶ月移動平均" stroke="#0ea5e9" strokeWidth={2} dot={false} />
         </ReBarChart>
       </ResponsiveContainer>
       </div>


### PR DESCRIPTION
## Summary
- compute 3-month moving average of monthly totals
- overlay moving average as a line on the monthly bar chart

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689ee27a1ed4832e9e9fa000572fbd2e