### PR TITLE
feat: enhance net balance chart with quarterly markers

### DIFF
--- a/src/NetBalanceLineChart.jsx
+++ b/src/NetBalanceLineChart.jsx
@@ -1,4 +1,14 @@
-import { LineChart, Line, XAxis, YAxis, Tooltip, CartesianGrid, ResponsiveContainer, ReferenceLine } from 'recharts';
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+  ResponsiveContainer,
+  ReferenceLine,
+  Brush,
+} from 'recharts';
 import { convertAmount, formatAmount } from './utils/currency.js';
 
 export default function NetBalanceLineChart({ transactions, period, yenUnit }) {
@@ -20,6 +30,13 @@ export default function NetBalanceLineChart({ transactions, period, yenUnit }) {
   const isMobile = typeof window !== 'undefined' && window.innerWidth < 768;
   const height = isMobile ? 250 : 300;
 
+  const quarterLines = data
+    .filter((d) => ['01', '04', '07', '10'].includes(d.month.slice(5, 7)))
+    .map((d) => {
+      const q = Math.floor((parseInt(d.month.slice(5, 7), 10) - 1) / 3) + 1;
+      return { x: d.month, label: `Q${q}` };
+    });
+
   const tickFormatter = (v) => v.toLocaleString();
   const tooltipFormatter = (v) => formatAmount(v, yenUnit);
 
@@ -28,11 +45,28 @@ export default function NetBalanceLineChart({ transactions, period, yenUnit }) {
       <ResponsiveContainer width="100%" height={height}>
         <LineChart data={data} margin={{ top: 16, right: 16, bottom: 8, left: 0 }}>
           <CartesianGrid strokeDasharray="3 3" />
-          <XAxis dataKey="month" />
+          <XAxis dataKey="month" interval={1} />
           <YAxis tickFormatter={tickFormatter} />
           <ReferenceLine y={0} stroke="#000" strokeWidth={4} />
+          {quarterLines.map((q) => (
+            <ReferenceLine
+              key={q.x}
+              x={q.x}
+              stroke="#ccc"
+              strokeWidth={1}
+              label={{ position: 'top', value: q.label, fill: '#94a3b8' }}
+            />
+          ))}
           <Tooltip formatter={tooltipFormatter} />
           <Line type="monotone" dataKey="diff" stroke="#8884d8" dot={{ r: 3 }} />
+          {isMobile && (
+            <Brush
+              dataKey="month"
+              height={20}
+              travellerWidth={10}
+              startIndex={Math.max(data.length - 6, 0)}
+            />
+          )}
         </LineChart>
       </ResponsiveContainer>
     </div>


### PR DESCRIPTION
## Summary
- show X-axis labels every other month
- draw quarter boundary lines labeled Q1/Q2/etc
- add mobile brush to zoom 6 months

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689ee27baa00832ebfa02f3c9797abf7