### PR TITLE
feat: add monthly amount heatmap

### DIFF
--- a/src/MonthAmountMatrix.jsx
+++ b/src/MonthAmountMatrix.jsx
@@ -1,0 +1,39 @@
+import { useMemo } from 'react';
+import { formatAmount } from './utils/currency.js';
+
+export default function MonthAmountMatrix({ transactions, kind = 'expense', yenUnit }) {
+  const { months, totals, max } = useMemo(() => {
+    const map = {};
+    transactions
+      .filter((tx) => tx.kind === kind)
+      .forEach((tx) => {
+        const month = tx.date.slice(0, 7);
+        map[month] = (map[month] || 0) + Math.abs(tx.amount);
+      });
+    const keys = Object.keys(map).sort();
+    const maxVal = Math.max(...Object.values(map), 0);
+    return { months: keys, totals: map, max: maxVal };
+  }, [transactions, kind]);
+
+  const colorFor = (val) => {
+    if (!max || val === 0) return '#f9fafb';
+    const ratio = val / max;
+    const lightness = 90 - 50 * ratio;
+    return `hsl(217, 91%, ${lightness}%)`;
+  };
+
+  return (
+    <div className="grid grid-cols-3 gap-2">
+      {months.map((m) => (
+        <div
+          key={m}
+          className="p-2 text-center rounded"
+          style={{ backgroundColor: colorFor(totals[m]) }}
+        >
+          <div>{m}</div>
+          <div>{formatAmount(totals[m], yenUnit)}</div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/pages/MonthlyAnalysis.jsx
+++ b/src/pages/MonthlyAnalysis.jsx
@@ -1,4 +1,5 @@
 import BarByMonth from '../BarByMonth.jsx';
+import MonthAmountMatrix from '../MonthAmountMatrix.jsx';
 
 export default function MonthlyAnalysis({
   transactions,
@@ -22,6 +23,14 @@ export default function MonthlyAnalysis({
           hideOthers={hideOthers}
           kind="expense"
           height={350}
+        />
+      </div>
+      <div className='card'>
+        <h3 style={{ marginBottom: 16 }}>月別ヒートマップ</h3>
+        <MonthAmountMatrix
+          transactions={transactions}
+          yenUnit={yenUnit}
+          kind="expense"
         />
       </div>
     </section>


### PR DESCRIPTION
## Summary
- visualize monthly totals in a 3-column heatmap with color scaling
- expose the heatmap on the MonthlyAnalysis page

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689ee2802d34832e8b648589ce266842