### PR TITLE
feat: memoize month bar colors

### DIFF
--- a/src/BarByMonth.jsx
+++ b/src/BarByMonth.jsx
@@ -106,8 +106,13 @@ export default function BarByMonth({
     const sum = data.reduce((acc, d) => acc + d.total, 0);
     return sum / data.length;
   }, [data]);
-
- // （ここはそのまま）dataWithColors は直前の useMemo の実装を採用
+  const dataWithColors = useMemo(() => {
+    const highlight = target ?? currentMonth;
+    return data.map(d => ({
+      ...d,
+      fill: d.month === highlight ? HIGHLIGHT_BAR_COLOR : DEFAULT_BAR_COLOR,
+    }));
+  }, [data, target, currentMonth]);
 
 // 直近3点の移動平均を付与（凡例やラインで使う場合に備えて）
 const dataWithMovingAvg = useMemo(() => {


### PR DESCRIPTION
## Summary
- memoize bar color selection for current or target month in bar chart

## Testing
- `pnpm build`
- `pnpm test` *(fails: Missing script: test)*

------
https://chatgpt.com/codex/tasks/task_e_689eecbf3724832e9dee79f32c46efdd