### PR TITLE
chore: use interval for auto sync

### DIFF
--- a/src/state/StoreContextWithDB.jsx
+++ b/src/state/StoreContextWithDB.jsx
@@ -425,13 +425,13 @@ export function StoreProvider({ children }) {
 
   useEffect(() => {
     // 自動同期が有効な場合のみ実行
-    if (autoSyncEnabled && session?.user?.id && state.syncStatus === 'pending') {
-      const timer = setTimeout(() => {
+    if (autoSyncEnabled && session?.user?.id) {
+      const intervalId = setInterval(() => {
         syncWithDatabase();
-      }, 1000);
-      return () => clearTimeout(timer);
+      }, 15 * 60 * 1000);
+      return () => clearInterval(intervalId);
     }
-  }, [autoSyncEnabled, session, state.syncStatus, syncWithDatabase]);
+  }, [autoSyncEnabled, session, syncWithDatabase]);
   
   // 自動同期の設定を変更する関数
   const toggleAutoSync = useCallback((enabled) => {


### PR DESCRIPTION
## Summary
- schedule database sync every 15 minutes
- cleanup interval on effect cleanup

## Testing
- `pnpm lint` *(fails: Parsing error in NetBalanceLineChart.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_689ef1759a10832ea164cbf9f72db593