### PR TITLE
中央揃えレイアウトと必要要素の左寄せ対応

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -461,6 +461,7 @@ body {
   z-index:1;
   gap:1rem;
   overflow-x:hidden;
+  text-align:center;
 }
 
 .card {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -767,7 +767,7 @@ function Dashboard({
       </Sheet>
 
       {/* コンテンツ */}
-      <main className='content'>
+      <main className='content text-center'>
         {state.transactions.length === 0 && (
           <Card className="text-center py-12">
             <CardContent>

--- a/src/NetBalanceLineChart.jsx
+++ b/src/NetBalanceLineChart.jsx
@@ -132,31 +132,25 @@ return (
         {/* ツールチップ（1つに統一） */}
         <Tooltip content={<CustomTooltip yenUnit={yenUnit} average={average} />} />
 
-        <Line
-          type="monotone"
-          dataKey="diff"
-          stroke="#8884d8"
-          dot={{ r: 3 }}
-        />
-      </LineChart>
-    </ResponsiveContainer>
-  </div>
-);
-
-
-        {/* PCのみブラシ。直近6か月を初期表示 */}
-        {!isMobile && (
-          <Brush
-            dataKey="month"
-            height={20}
-            travellerWidth={10}
-            startIndex={Math.max(data.length - 6, 0)}
+          <Line
+            type="monotone"
+            dataKey="diff"
+            stroke="#8884d8"
+            dot={{ r: 3 }}
           />
-        )}
-      </LineChart>
-    </ResponsiveContainer>
-  </div>
-);
+          {/* PCのみブラシ。直近6か月を初期表示 */}
+          {!isMobile && (
+            <Brush
+              dataKey="month"
+              height={20}
+              travellerWidth={10}
+              startIndex={Math.max(data.length - 6, 0)}
+            />
+          )}
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
 }
 
 

--- a/src/OthersTable.jsx
+++ b/src/OthersTable.jsx
@@ -102,9 +102,9 @@ export default function OthersTable({ rows, addRule, isMobile, kind, yenUnit }) 
   const categories = state.categories;
 
   return (
-    <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+    <table className='text-left' style={{ width: '100%', borderCollapse: 'collapse' }}>
       <thead>
-        <tr style={{ textAlign: 'left' }}>
+        <tr>
           <th style={{ borderBottom: '1px solid #eee', padding: 6 }}>店舗/内容</th>
           <th style={{ borderBottom: '1px solid #eee', padding: 6, width: 140 }}>{kind === 'income' ? '収入合計' : '支出合計'}</th>
           <th style={{ borderBottom: '1px solid #eee', padding: 6, width: 260 }}>カテゴリに登録</th>

--- a/src/components/Auth.jsx
+++ b/src/components/Auth.jsx
@@ -296,7 +296,7 @@ export default function Auth({ onSkipAuth }) {
           </p>
         )}
 
-        <form onSubmit={handleAuth} className="auth-form">
+        <form onSubmit={handleAuth} className="auth-form text-left">
           <div className="form-group">
             <label htmlFor="email">メールアドレス</label>
             <input

--- a/src/components/PasswordReset.jsx
+++ b/src/components/PasswordReset.jsx
@@ -113,7 +113,7 @@ export default function PasswordReset() {
           <div className="auth-message error">{error}</div>
         )}
 
-        <form onSubmit={handlePasswordUpdate} className="auth-form">
+        <form onSubmit={handlePasswordUpdate} className="auth-form text-left">
           <div className="form-group">
             <label htmlFor="password">新しいパスワード</label>
             <input

--- a/src/pages/Categories.jsx
+++ b/src/pages/Categories.jsx
@@ -120,7 +120,7 @@ export default function Categories() {
         <p style={{ marginBottom: 12, color: '#666', fontSize: '0.9em' }}>
           ドラッグ&ドロップまたは↑↓ボタンで並び順を変更できます
         </p>
-        <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+        <table className='text-left' style={{ width: '100%', borderCollapse: 'collapse' }}>
           <tbody>
             {categories.map((c, idx) => (
               <tr 
@@ -198,7 +198,7 @@ export default function Categories() {
             ))}
           </tbody>
         </table>
-        <form onSubmit={addCategory} style={{ marginTop: 12, display: 'flex', gap: 4 }}>
+        <form onSubmit={addCategory} className='text-left' style={{ marginTop: 12, display: 'flex', gap: 4 }}>
           <input
             type='text'
             value={newCat}

--- a/src/pages/ForgotPassword.jsx
+++ b/src/pages/ForgotPassword.jsx
@@ -43,7 +43,7 @@ export default function ForgotPassword() {
             {error}
           </p>
         )}
-        <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '.75rem' }}>
+        <form onSubmit={handleSubmit} className='text-left' style={{ display: 'flex', flexDirection: 'column', gap: '.75rem' }}>
           <label htmlFor='email'>メールアドレス</label>
           <input
             id='email'

--- a/src/pages/ImportCsv.jsx
+++ b/src/pages/ImportCsv.jsx
@@ -309,7 +309,7 @@ export default function ImportCsv() {
                 </div>
                 
                 <div className="overflow-x-auto">
-                  <table className="min-w-full text-sm border-collapse">
+                  <table className="min-w-full text-sm border-collapse text-left">
                     <thead>
                       <tr className="border-b">
                         {KNOWN_FIELDS.filter((f) => headerMap[f]).map((f) => (

--- a/src/pages/Monthly.jsx
+++ b/src/pages/Monthly.jsx
@@ -476,7 +476,7 @@ export default function Monthly({
               </CardHeader>
               <CardContent>
                 <div className="overflow-x-auto">
-                  <table className="w-full">
+                  <table className="w-full text-left">
                     <thead>
                       <tr className="border-b">
                         <th className="text-left p-2 text-sm font-medium">日付</th>

--- a/src/pages/PasswordResetCallback.jsx
+++ b/src/pages/PasswordResetCallback.jsx
@@ -68,7 +68,7 @@ export default function PasswordResetCallback() {
       <h2>パスワード更新</h2>
       <div className='card'>
         {error && <p style={{ color: 'red' }}>{error}</p>}
-        <form onSubmit={handleSubmit}>
+        <form onSubmit={handleSubmit} className='text-left'>
           <label htmlFor='password'>新しいパスワード</label>
           <div className='password-field'>
             <input

--- a/src/pages/Rules.jsx
+++ b/src/pages/Rules.jsx
@@ -115,9 +115,9 @@ export default function Rules() {
       )}
       <div className='card'>
         <div style={{ marginBottom: 8 }}>（{rules.length}件のルール）</div>
-        <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+        <table className='text-left' style={{ width: '100%', borderCollapse: 'collapse' }}>
           <thead>
-            <tr style={{ textAlign: 'left', backgroundColor: '#f0f0f0' }}>
+            <tr className='text-left' style={{ backgroundColor: '#f0f0f0' }}>
               <th style={{ borderBottom: '2px solid #ddd', padding: 8, fontWeight: 'bold' }}>パターン</th>
               <th style={{ borderBottom: '2px solid #ddd', padding: 8, fontWeight: 'bold' }}>モード</th>
               <th style={{ borderBottom: '2px solid #ddd', padding: 8, fontWeight: 'bold' }}>対象</th>
@@ -234,6 +234,7 @@ export default function Rules() {
 
         <form
           onSubmit={addRule}
+          className='text-left'
           style={{
             display: 'flex',
             flexWrap: 'wrap',

--- a/src/pages/Transactions.jsx
+++ b/src/pages/Transactions.jsx
@@ -450,7 +450,7 @@ useEffect(() => {
           </CardHeader>
           <CardContent>
             <div className="overflow-x-auto">
-              <table className="w-full border-collapse min-w-[600px]">
+              <table className="w-full border-collapse min-w-[600px] text-left">
                 <thead>
                   <tr className="border-b-2 border-gray-200">
                     <th className="text-left p-3 font-semibold text-gray-700 whitespace-nowrap">


### PR DESCRIPTION
## Summary
- `.content` を中央揃えにし、`<main>` に `text-center` を追加
- テーブルやフォームなど左寄せが必要な要素へ `text-left` を付与
- NetBalanceLineChart の構文エラーを修正

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689ef0e6ccb8832eb4e625cd5422afdc