### PR TITLE
feat: add periodic sync prompt

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -112,7 +112,7 @@ function serializeHash({
 }
 
 export default function App() {
-  const { state, dispatch, loadFromDatabase } = useStore();
+  const { state, dispatch, loadFromDatabase, syncWithDatabase, showSyncPrompt, hideSyncPrompt } = useStore();
   const { session, loading } = useSession();
   const isLocalMode = localStorage.getItem('localMode') === 'true';
   const [syncing, setSyncing] = useState(false);
@@ -631,6 +631,26 @@ function Dashboard({
 
   return (
     <div className='app-shell'>
+      {showSyncPrompt && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="bg-white p-6 rounded shadow">
+            <p className="mb-4">同期を実行しますか？</p>
+            <div className="flex justify-end gap-2">
+              <Button
+                onClick={async () => {
+                  await syncWithDatabase();
+                  hideSyncPrompt();
+                }}
+              >
+                同期
+              </Button>
+              <Button variant="outline" onClick={hideSyncPrompt}>
+                キャンセル
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
       {/* ヘッダー */}
       <header className='header'>
         <div className='header-controls'>

--- a/src/state/StoreContextWithDB.jsx
+++ b/src/state/StoreContextWithDB.jsx
@@ -298,6 +298,10 @@ export function StoreProvider({ children }) {
     const stored = localStorage.getItem('autoSyncEnabled');
     return stored !== null ? stored === 'true' : true;
   });
+  const [showSyncPrompt, setShowSyncPrompt] = useState(false);
+
+  const showSyncPromptFn = useCallback(() => setShowSyncPrompt(true), []);
+  const hideSyncPrompt = useCallback(() => setShowSyncPrompt(false), []);
 
   const syncWithDatabase = useCallback(
     async (overrideTransactions) => {
@@ -432,6 +436,13 @@ export function StoreProvider({ children }) {
       return () => clearTimeout(timer);
     }
   }, [autoSyncEnabled, session, state.syncStatus, syncWithDatabase]);
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setShowSyncPrompt(true);
+    }, 15 * 60 * 1000);
+    return () => clearInterval(timer);
+  }, []);
   
   // 自動同期の設定を変更する関数
   const toggleAutoSync = useCallback((enabled) => {
@@ -448,7 +459,10 @@ export function StoreProvider({ children }) {
         syncWithDatabase,
         loadFromDatabase,
         autoSyncEnabled,
-        toggleAutoSync
+        toggleAutoSync,
+        showSyncPrompt,
+        showSyncPromptFn,
+        hideSyncPrompt
       }}
     >
       {children}


### PR DESCRIPTION
## Summary
- show sync prompt after 15 minutes in StoreContextWithDB
- expose show/hide functions via context
- display modal in App to run or skip sync

## Testing
- `pnpm lint` (fails: Parsing error in src/NetBalanceLineChart.jsx)


------
https://chatgpt.com/codex/tasks/task_e_689ef179adac832e83b7ea0eeb7c67b6