### PR TITLE
refactor: simplify monthly view

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -239,11 +239,6 @@ export default function App() {
     };
   }, []);
 
-  const updateFilterMode = mode => {
-    localStorage.setItem('filterMode', JSON.stringify(mode));
-    setFilterMode(mode);
-  };
-
   // 集計対象外を除外したトランザクション
   const filteredTransactionsForAnalysis = useMemo(() => {
     let txs = state.transactions.filter(tx => !tx.excludeFromTotals);
@@ -910,13 +905,10 @@ function Dashboard({
                 </Card>
                 <Monthly
                   transactions={filteredTransactionsForAnalysis}
-                  period={period}
                   yenUnit={yenUnit}
                   lockColors={lockColors}
                   hideOthers={hideOthers}
                   kind={kind}
-                  filterMode={filterMode}
-                  onFilterModeChange={updateFilterMode}
                 />
               </Suspense>
             </TabsContent>


### PR DESCRIPTION
## Summary
- remove extra filters from Monthly page and show month selector only
- derive top categories automatically in CategoryComparison
- drop unused filter props

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_689efa8eba1c832e800a459e0e6cf3ca