### PR TITLE
feat: allow disabling chart animations

### DIFF
--- a/src/BalanceChart.jsx
+++ b/src/BalanceChart.jsx
@@ -12,7 +12,12 @@ import {
 } from 'recharts';
 import { formatAmount } from './utils/currency.js';
 
-export default function BalanceChart({ transactions, period, yenUnit }) {
+export default function BalanceChart({
+  transactions,
+  period,
+  yenUnit,
+  isAnimationActive = false,
+}) {
   const data = useMemo(() => {
     const monthMap = {};
     transactions.forEach(tx => {
@@ -61,15 +66,22 @@ export default function BalanceChart({ transactions, period, yenUnit }) {
     >
       <div style={{ width: chartWidth, height: 200 }}>
         <ResponsiveContainer width='100%' height='100%'>
-          <ComposedChart data={data}>
+          <ComposedChart data={data} isAnimationActive={isAnimationActive}>
             <CartesianGrid strokeDasharray='3 3' />
             <XAxis dataKey='month' />
             <YAxis domain={domain} tickFormatter={v => formatAmount(v, yenUnit)} />
             <ReferenceLine y={0} stroke='#000' strokeWidth={4} />
             <Tooltip formatter={tooltipFormatter} />
-            <Bar dataKey='income' fill='#34d399' name='収入' />
-            <Bar dataKey='expense' fill='#f87171' name='支出' />
-            <Line type='monotone' dataKey='diff' stroke='#3b82f6' dot={false} name='差分' />
+            <Bar dataKey='income' fill='#34d399' name='収入' isAnimationActive={isAnimationActive} />
+            <Bar dataKey='expense' fill='#f87171' name='支出' isAnimationActive={isAnimationActive} />
+            <Line
+              type='monotone'
+              dataKey='diff'
+              stroke='#3b82f6'
+              dot={false}
+              name='差分'
+              isAnimationActive={isAnimationActive}
+            />
           </ComposedChart>
         </ResponsiveContainer>
       </div>

--- a/src/NetBalanceLineChart.jsx
+++ b/src/NetBalanceLineChart.jsx
@@ -29,7 +29,12 @@ function CustomTooltip({ active, payload, label, formatDiffValue, average }) {
   );
 }
 
-export default function NetBalanceLineChart({ transactions, period, yenUnit }) {
+export default function NetBalanceLineChart({
+  transactions,
+  period,
+  yenUnit,
+  isAnimationActive = false,
+}) {
   const { data, average, quarterLines } = useMemo(() => {
     // ---- 集計 ----------------------------------------------------------
     const monthMap = {};
@@ -81,49 +86,51 @@ export default function NetBalanceLineChart({ transactions, period, yenUnit }) {
         <LineChart
           data={data}
           margin={{ top: 16, right: 16, bottom: 8, left: 0 }}
-      >
-        <CartesianGrid strokeDasharray="3 3" />
+          isAnimationActive={isAnimationActive}
+        >
+          <CartesianGrid strokeDasharray="3 3" />
 
-        {/* 目盛りフォーマット */}
-        <YAxis tickFormatter={(v) => yFmt(v, yenUnit)} />
-        {/* 隔月表示: interval={1} で 2つに1つだけ表示 */}
-        <XAxis dataKey="month" tickFormatter={formatMonth} interval={1} />
+          {/* 目盛りフォーマット */}
+          <YAxis tickFormatter={(v) => yFmt(v, yenUnit)} />
+          {/* 隔月表示: interval={1} で 2つに1つだけ表示 */}
+          <XAxis dataKey="month" tickFormatter={formatMonth} interval={1} />
 
-        {/* 0円基準線 */}
-        <ReferenceLine y={0} stroke="#000" strokeWidth={1} />
+          {/* 0円基準線 */}
+          <ReferenceLine y={0} stroke="#000" strokeWidth={1} />
 
-        {/* 四半期の区切り線とラベル */}
-        {quarterLines.map((q) => (
-          <ReferenceLine
-            key={q.x}
-            x={q.x}
-            stroke="#ccc"
-            strokeWidth={1}
-            label={{ position: 'top', value: q.label, fill: '#94a3b8' }}
+          {/* 四半期の区切り線とラベル */}
+          {quarterLines.map((q) => (
+            <ReferenceLine
+              key={q.x}
+              x={q.x}
+              stroke="#ccc"
+              strokeWidth={1}
+              label={{ position: 'top', value: q.label, fill: '#94a3b8' }}
+            />
+          ))}
+
+          {/* ツールチップ（1つに統一） */}
+          <Tooltip
+            content={<CustomTooltip formatDiffValue={formatDiffValue} average={average} />}
           />
-        ))}
-
-        {/* ツールチップ（1つに統一） */}
-        <Tooltip
-          content={<CustomTooltip formatDiffValue={formatDiffValue} average={average} />}
-        />
-        <Line
-          type="monotone"
-          dataKey="diff"
-          stroke="#8884d8"
-          dot={{ r: 3 }}
-        />
-        {/* PCのみブラシ。直近6か月を初期表示 */}
-        {!isMobile && (
-          <Brush
-            dataKey="month"
-            height={20}
-            travellerWidth={10}
-            startIndex={Math.max(data.length - 6, 0)}
+          <Line
+            type="monotone"
+            dataKey="diff"
+            stroke="#8884d8"
+            dot={{ r: 3 }}
+            isAnimationActive={isAnimationActive}
           />
-        )}
-      </LineChart>
-    </ResponsiveContainer>
+          {/* PCのみブラシ。直近6か月を初期表示 */}
+          {!isMobile && (
+            <Brush
+              dataKey="month"
+              height={20}
+              travellerWidth={10}
+              startIndex={Math.max(data.length - 6, 0)}
+            />
+          )}
+        </LineChart>
+      </ResponsiveContainer>
   </div>
 );
 }


### PR DESCRIPTION
## Summary
- add `isAnimationActive` prop to balance charts
- disable Recharts animations by default for `Line`, `Bar`, and `ComposedChart`

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689f0275bea4832eb327afa179d39dd0