### PR TITLE
カード支払い取引のフラグ追加とフィルタ改善

### DIFF
--- a/scripts/migrate-card-payment-flag.js
+++ b/scripts/migrate-card-payment-flag.js
@@ -1,0 +1,42 @@
+import fs from 'fs';
+
+const file = process.argv[2];
+if (!file) {
+  console.error('Usage: node scripts/migrate-card-payment-flag.js <data-file.json>');
+  process.exit(1);
+}
+
+let raw;
+try {
+  raw = fs.readFileSync(file, 'utf8');
+} catch (err) {
+  console.error('Failed to read file:', err.message);
+  process.exit(1);
+}
+
+let data;
+try {
+  data = JSON.parse(raw);
+} catch (err) {
+  console.error('Invalid JSON:', err.message);
+  process.exit(1);
+}
+
+const txs = Array.isArray(data) ? data : data.transactions || [];
+let updatedCount = 0;
+const updated = txs.map(tx => {
+  if (tx.category === 'カード支払い' && !tx.isCardPayment) {
+    updatedCount++;
+    return { ...tx, isCardPayment: true };
+  }
+  return tx;
+});
+
+if (Array.isArray(data)) {
+  fs.writeFileSync(file, JSON.stringify(updated, null, 2));
+} else {
+  const result = { ...data, transactions: updated };
+  fs.writeFileSync(file, JSON.stringify(result, null, 2));
+}
+
+console.log(`Updated ${updatedCount} transactions`);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -257,9 +257,9 @@ export default function App() {
     }
 
     if (filterMode.card === 'exclude') {
-      txs = txs.filter(tx => tx.category !== 'カード支払い');
+      txs = txs.filter(tx => !tx.isCardPayment);
     } else if (filterMode.card === 'only') {
-      txs = txs.filter(tx => tx.category === 'カード支払い');
+      txs = txs.filter(tx => tx.isCardPayment);
     }
 
     if (filterMode.rent === 'exclude') {

--- a/src/defaultCategories.js
+++ b/src/defaultCategories.js
@@ -14,7 +14,7 @@ export const DEFAULT_CATEGORIES = [
   '交際費',
   'ビジネス',
   'Amazon',
-  'カード払い',
+  'カード支払い',
   '税金・保険',
   'その他',
   '収入',

--- a/src/pages/ImportCsv.jsx
+++ b/src/pages/ImportCsv.jsx
@@ -159,7 +159,7 @@ export default function ImportCsv() {
       );
       
       if (isCardPayment && tx.amount < 0) {
-        return { ...tx, category: 'カード支払い' };
+        return { ...tx, category: 'カード支払い', isCardPayment: true };
       }
       return tx;
     });

--- a/src/pages/Transactions.jsx
+++ b/src/pages/Transactions.jsx
@@ -54,10 +54,7 @@ const filtered = useMemo(() => {
   return txs.filter((tx) => {
     // 既存フィルタ
     if (showUnclassifiedOnly && tx.category) return false;
-    if (
-      excludeCardPayments &&
-      (tx.category === 'カード支払い' || tx.category === 'カード払い' || tx.category === 'クレカ払い')
-    ) return false;
+    if (excludeCardPayments && tx.isCardPayment) return false;
 
     if (startDate && tx.date < startDate) return false;
     if (endDate && tx.date > endDate) return false;

--- a/src/services/database.js
+++ b/src/services/database.js
@@ -69,6 +69,8 @@ export const dbService = {
         const hash = tx.hash || hashString;
         const excludeFromTotals =
           tx.excludeFromTotals ?? tx.exclude_from_totals ?? false;
+        const isCardPayment =
+          tx.isCardPayment ?? tx.is_card_payment ?? tx.category === 'カード支払い';
 
         return {
           id: tx.id || crypto.randomUUID(), // 既存のIDを使用、なければ新規生成
@@ -82,7 +84,8 @@ export const dbService = {
           memo: tx.memo || tx.メモ || '', // text型
           kind: tx.kind || tx.種別 || (amount < 0 ? 'expense' : 'income'), // text型
           hash,
-          exclude_from_totals: excludeFromTotals // boolean型（集計対象外フラグ）
+          exclude_from_totals: excludeFromTotals, // boolean型（集計対象外フラグ）
+          is_card_payment: isCardPayment
         };
       });
 

--- a/src/state/StoreContext.jsx
+++ b/src/state/StoreContext.jsx
@@ -70,6 +70,8 @@ function reducer(state, action) {
           transactions = transactions.map(tx => ({
             ...tx,
             kind: tx.kind || (tx.amount < 0 ? 'expense' : 'income'),
+            isCardPayment:
+              tx.isCardPayment || tx.is_card_payment || tx.category === 'カード支払い',
           }));
         } catch {
           // ignore

--- a/src/state/StoreContextWithDB.jsx
+++ b/src/state/StoreContextWithDB.jsx
@@ -62,6 +62,8 @@ function reducer(state, action) {
             ...tx,
             id: tx.id || crypto.randomUUID(),
             kind: tx.kind || (tx.amount < 0 ? 'expense' : 'income'),
+            isCardPayment:
+              tx.isCardPayment || tx.is_card_payment || tx.category === 'カード支払い',
           }));
         } catch {
           // ignore
@@ -100,6 +102,8 @@ function reducer(state, action) {
         ...tx,
         date: tx.date || tx.occurred_on,  // occurred_onフィールドからdateを復元
         kind: tx.kind || (tx.amount < 0 ? 'expense' : 'income'),
+        isCardPayment:
+          tx.isCardPayment || tx.is_card_payment || tx.category === 'カード支払い',
       }));
       localStorage.setItem('lm_rules_v1', JSON.stringify(rules));
       localStorage.setItem(

--- a/src/types.js
+++ b/src/types.js
@@ -8,6 +8,7 @@
  * @property {'income'|'expense'} kind - Transaction kind.
  * @property {string} [category] - Category assigned to the transaction.
  * @property {boolean} [excludeFromTotals] - Whether to exclude from totals calculations.
+ * @property {boolean} [isCardPayment] - True if the transaction is a card payment.
  * @property {string} [id] - Unique identifier for the transaction.
  */
 


### PR DESCRIPTION
## Summary
- CSV取込時にカード支払いを自動判定し、`isCardPayment` フラグを付与
- 分析・取引一覧のフィルタを `isCardPayment` フラグ基準に変更
- 既存データ用にカード支払いカテゴリへフラグを付与する移行スクリプトを追加

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689f25b91b50832eab4bbd02f60f5f93