### PR TITLE
feat: auto apply rules after changes

### DIFF
--- a/src/pages/Rules.jsx
+++ b/src/pages/Rules.jsx
@@ -37,6 +37,7 @@ export default function Rules() {
 
   const saveRules = updated => {
     dispatch({ type: 'setRules', payload: updated });
+    dispatch({ type: 'applyRules' });
   };
 
   const addRule = e => {

--- a/src/pages/Transactions.jsx
+++ b/src/pages/Transactions.jsx
@@ -114,6 +114,13 @@ useEffect(() => {
   }
 }, [startDate, endDate, loadFromDatabase]);
 
+// ルール変更時に自動で再適用
+useEffect(() => {
+  if (state.rules) {
+    dispatch({ type: 'applyRules' });
+  }
+}, [state.rules, dispatch]);
+
   // lastApplyResultの変更を監視してメッセージを更新
   useEffect(() => {
     if (state.lastApplyResult) {
@@ -167,13 +174,8 @@ useEffect(() => {
     const rules = state.rules || [];
     const updatedRules = [...rules, newRule];
     dispatch({ type: 'setRules', payload: updatedRules });
-    // ルール保存後、自動的に未分類の取引にルールを適用
     setRuleAppliedMessage('ルールを保存し、全取引に適用しています...');
-    setTimeout(() => {
-      dispatch({ type: 'applyRules' });
-      setRuleAppliedMessage('ルールが適用されました');
-      setTimeout(() => setRuleAppliedMessage(''), 3000);
-    }, 100);
+    setApplyingRules(true);
     setShowRuleModal(false);
     setSelectedTx(null);
   };


### PR DESCRIPTION
## Summary
- apply reclassification rules to transactions right after saving rules
- automatically reapply rules in Transactions page when rules change

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_689f284d5c34832e86bc8c7cba45f39a