### PR TITLE
feat: allow skipping rule reload

### DIFF
--- a/src/pages/Transactions.jsx
+++ b/src/pages/Transactions.jsx
@@ -107,6 +107,7 @@ useEffect(() => {
     loadFromDatabase({
       startDate: startDate || undefined,
       endDate: endDate || undefined,
+      skipRules: true,
     });
   }
 }, [startDate, endDate, loadFromDatabase]);


### PR DESCRIPTION
## Summary
- add optional `skipRules` flag to `loadFromDatabase` so callers can skip rule fetching
- avoid resetting rules when `skipRules` is true
- pass `skipRules: true` from `Transactions` page to prevent unnecessary rule reloads

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689f2bb15c74832eb6f8406cb8663e88