### PR TITLE
feat: sync backup on offline/online events

### DIFF
--- a/src/state/StoreContextWithDB.jsx
+++ b/src/state/StoreContextWithDB.jsx
@@ -44,7 +44,8 @@ function applyRulesToTransactions(transactions, rules) {
 
 function reducer(state, action) {
   switch (action.type) {
-    case 'loadFromStorage': {
+    case 'loadFromStorage':
+    case 'loadFromBackup': {
       let transactions = [];
       let lastImportAt = null;
       let categories = DEFAULT_CATEGORIES;
@@ -93,7 +94,11 @@ function reducer(state, action) {
       } else {
         localStorage.setItem('lm_categories_v1', JSON.stringify(categories));
       }
-      return { ...state, transactions, rules, categories, lastImportAt };
+      const newState = { ...state, transactions, rules, categories, lastImportAt };
+      if (action.type === 'loadFromBackup') {
+        newState.syncStatus = 'offline';
+      }
+      return newState;
     }
     
     case 'loadFromDatabase': {


### PR DESCRIPTION
## Summary
- handle offline and online browser events in App component
- reload from local backup when offline and fetch from database when online
- show toast notifications about sync status

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_689fafb7949c832e805e80e26a8f2934