### PR TITLE
Ensure graceful fallback when Supabase session fails

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -115,7 +115,8 @@ function serializeHash({
 export default function App() {
   const { state, dispatch, loadFromDatabase } = useStore();
   const { session, loading } = useSession();
-  const isLocalMode = localStorage.getItem('localMode') === 'true';
+  const isLocalMode =
+    localStorage.getItem('localMode') === 'true' || (!loading && !session);
   const [syncing, setSyncing] = useState(false);
 
   const isAuthenticated = session || isLocalMode;

--- a/src/useSession.js
+++ b/src/useSession.js
@@ -13,10 +13,18 @@ export function useSession() {
     }
     
     // Get initial session
-    supabase.auth.getSession().then(({ data }) => {
-      setSession(data.session);
-      setLoading(false);
-    });
+    supabase.auth
+      .getSession()
+      .then(({ data }) => {
+        setSession(data.session);
+      })
+      .catch((error) => {
+        console.error('Error getting session:', error);
+        setSession(null);
+      })
+      .finally(() => {
+        setLoading(false);
+      });
     
     // Listen for auth changes
     const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {


### PR DESCRIPTION
## Summary
- Catch errors from `supabase.auth.getSession` and always clear loading state
- Fall back to local backup mode when no session is available

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689fb06f2b24832ebf006ce582524ea3