### PR TITLE
feat: handle uncategorized transactions

### DIFF
--- a/src/BarByCategory.jsx
+++ b/src/BarByCategory.jsx
@@ -10,7 +10,7 @@ import {
   Legend,
   Cell,
 } from 'recharts';
-import { DEFAULT_CATEGORIES as CATEGORIES } from './defaultCategories.js';
+import { DEFAULT_CATEGORIES as CATEGORIES, UNCATEGORIZED_LABEL } from './defaultCategories.js';
 
 const DEFAULT_BAR_COLOR = '#3b82f6';
 
@@ -83,7 +83,7 @@ export default function BarByCategory({
 
   const totals = {};
   filteredTx.forEach((tx) => {
-    const cat = tx.category || 'その他';
+    const cat = tx.category || UNCATEGORIZED_LABEL;
     if (hideOthers && cat === 'その他') return;
     totals[cat] = (totals[cat] || 0) + Math.abs(tx.amount);
   });

--- a/src/CategoryComparison.jsx
+++ b/src/CategoryComparison.jsx
@@ -1,4 +1,5 @@
 import { useRef, useMemo } from 'react';
+import { UNCATEGORIZED_LABEL } from './defaultCategories.js';
 import { formatAmount } from './utils/currency.js';
 import {
   ResponsiveContainer,
@@ -78,7 +79,7 @@ export default function CategoryComparison({
   const filtered = useMemo(() => {
     return transactions.filter((tx) => {
       if (tx.kind !== kind) return false;
-      const cat = tx.category || 'その他';
+      const cat = tx.category || UNCATEGORIZED_LABEL;
       if (hideOthers && cat === 'その他') return false;
       return true;
     });
@@ -87,7 +88,7 @@ export default function CategoryComparison({
   const monthMap = {};
   filtered.forEach((tx) => {
     const month = tx.date.slice(0, 7);
-    const cat = tx.category || 'その他';
+    const cat = tx.category || UNCATEGORIZED_LABEL;
     monthMap[month] = monthMap[month] || {};
     monthMap[month][cat] = (monthMap[month][cat] || 0) + Math.abs(tx.amount);
   });
@@ -103,7 +104,7 @@ export default function CategoryComparison({
     }
     const totals = {};
     filtered.forEach((tx) => {
-      const cat = tx.category || 'その他';
+      const cat = tx.category || UNCATEGORIZED_LABEL;
       totals[cat] = (totals[cat] || 0) + Math.abs(tx.amount);
     });
     return Object.entries(totals)

--- a/src/PieByCategory.jsx
+++ b/src/PieByCategory.jsx
@@ -1,5 +1,6 @@
 import { useRef, useMemo, useEffect } from 'react';
 import { formatAmount } from './utils/currency.js';
+import { UNCATEGORIZED_LABEL } from './defaultCategories.js';
 import {
   ResponsiveContainer,
   PieChart as RePieChart,
@@ -105,7 +106,7 @@ export default function PieByCategory({
 
   const totals = {};
   filteredTx.forEach((tx) => {
-    const cat = tx.category || 'その他';
+    const cat = tx.category || UNCATEGORIZED_LABEL;
     totals[cat] = (totals[cat] || 0) + Math.abs(tx.amount);
   });
   const totalSum = Object.values(totals).reduce((s, v) => s + v, 0);
@@ -113,7 +114,7 @@ export default function PieByCategory({
   let othersValue = 0;
   Object.entries(totals).forEach(([name, value]) => {
     const ratio = totalSum ? value / totalSum : 0;
-    if (name === 'その他' || ratio < 0.03) {
+    if (name === 'その他' || (name !== UNCATEGORIZED_LABEL && ratio < 0.03)) {
       othersValue += value;
     } else {
       items.push({ name, value });

--- a/src/defaultCategories.js
+++ b/src/defaultCategories.js
@@ -1,3 +1,5 @@
+export const UNCATEGORIZED_LABEL = '未分類';
+
 export const DEFAULT_CATEGORIES = [
   '食費',
   '外食費',

--- a/src/pages/Monthly.jsx
+++ b/src/pages/Monthly.jsx
@@ -1,6 +1,7 @@
 import { useMemo, useState, useEffect } from 'react';
 import PieByCategory from '../PieByCategory.jsx';
 import CategoryComparison from '../CategoryComparison.jsx';
+import { UNCATEGORIZED_LABEL } from '../defaultCategories.js';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Label } from '@/components/ui/label';
@@ -48,7 +49,7 @@ export default function Monthly({
   const topCategories = useMemo(() => {
     const totals = {};
     monthTxs.forEach((tx) => {
-      const cat = tx.category || 'その他';
+      const cat = tx.category || UNCATEGORIZED_LABEL;
       if (hideOthers && cat === 'その他') return;
       totals[cat] = (totals[cat] || 0) + Math.abs(tx.amount);
     });
@@ -101,7 +102,7 @@ export default function Monthly({
   const categoryDetails = useMemo(() => {
     const categoryMap = {};
     monthTxs.forEach((tx) => {
-      const cat = tx.category || 'その他';
+      const cat = tx.category || UNCATEGORIZED_LABEL;
       if (!categoryMap[cat]) {
         categoryMap[cat] = { amount: 0, count: 0, transactions: [] };
       }
@@ -361,7 +362,7 @@ export default function Monthly({
                           <td className="p-2 text-sm">{tx.date}</td>
                           <td className="p-2 text-sm">
                             <Badge variant="outline" className="text-xs">
-                              {tx.category || 'その他'}
+                              {tx.category || UNCATEGORIZED_LABEL}
                             </Badge>
                           </td>
                           <td className="p-2 text-sm text-muted-foreground">

--- a/src/pages/Transactions.jsx
+++ b/src/pages/Transactions.jsx
@@ -1,5 +1,6 @@
 import { useState, useMemo, useEffect } from 'react';
 import { useStore } from '../state/StoreContextWithDB';
+import { UNCATEGORIZED_LABEL } from '../defaultCategories.js';
 import { toast } from 'react-hot-toast';
 import Papa from 'papaparse';
 import * as XLSX from 'xlsx';
@@ -24,7 +25,7 @@ export default function Transactions() {
   /** @type {Transaction[]} */
   const txs = state.transactions;
   const categories = state.categories;
-  const unclassifiedCount = txs.filter(tx => !tx.category).length;
+  const unclassifiedCount = txs.filter(tx => tx.category === UNCATEGORIZED_LABEL).length;
   const [startDate, setStartDate] = useState('');
   const [endDate, setEndDate] = useState('');
   const [selectedCategory, setSelectedCategory] = useState('');
@@ -55,7 +56,7 @@ export default function Transactions() {
 const filtered = useMemo(() => {
   return txs.filter((tx) => {
     // 既存フィルタ
-    if (showUnclassifiedOnly && tx.category) return false;
+    if (showUnclassifiedOnly && tx.category !== UNCATEGORIZED_LABEL) return false;
     if (excludeCardPayments && tx.isCardPayment) return false;
 
     if (startDate && tx.date < startDate) return false;
@@ -65,7 +66,7 @@ const filtered = useMemo(() => {
     if (selectedCategory && selectedCategory !== '' && tx.category !== selectedCategory) return false;
 
     if (categoryQuery && categoryQuery.trim() !== '') {
-      const c = (tx.category || '').toLowerCase();
+      const c = (tx.category || UNCATEGORIZED_LABEL).toLowerCase();
       if (!c.includes(categoryQuery.toLowerCase().trim())) return false;
     }
 
@@ -165,7 +166,7 @@ useEffect(() => {
       pattern: tx.description || tx.detail || '',
       mode: 'contains',
       target: 'description',
-      category: tx.category || categories[0] || 'その他',
+      category: tx.category || categories[0] || UNCATEGORIZED_LABEL,
       kind: tx.kind || 'both',
     });
     setShowRuleModal(true);
@@ -601,7 +602,7 @@ useEffect(() => {
                           <td className="p-3 text-sm">{tx.date}</td>
                           <td className="p-3">
                             <Select
-                              value={editedCategories[tx.id] || tx.category || ''}
+                              value={editedCategories[tx.id] || tx.category || UNCATEGORIZED_LABEL}
                               onValueChange={(value) => handleCategoryChange(tx.id, value)}
                             >
                               <SelectTrigger className={`w-full h-8 text-xs ${
@@ -777,7 +778,7 @@ useEffect(() => {
                       <div>金額: {selectedTx.amount.toLocaleString()}円</div>
                       <div>現在のカテゴリ: 
                         <Badge variant="outline" className="ml-1">
-                          {selectedTx.category || '未分類'}
+                          {selectedTx.category || UNCATEGORIZED_LABEL}
                         </Badge>
                       </div>
                     </div>

--- a/src/state/StoreContext.jsx
+++ b/src/state/StoreContext.jsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useReducer, useEffect } from 'react';
-import { DEFAULT_CATEGORIES } from '../defaultCategories';
+import { DEFAULT_CATEGORIES, UNCATEGORIZED_LABEL } from '../defaultCategories';
 /** @typedef {import('../types').Transaction} Transaction */
 /** @typedef {import('../types').Rule} Rule */
 /** @typedef {import('../types').StoreState} StoreState */
@@ -42,7 +42,8 @@ function applyRulesToTransactions(transactions, rules) {
         return false;
       }
     });
-    return matched ? { ...tx, category: matched.category } : tx;
+    const category = matched ? matched.category : tx.category;
+    return { ...tx, category: category || UNCATEGORIZED_LABEL };
   });
 }
 
@@ -72,6 +73,7 @@ function reducer(state, action) {
             kind: tx.kind || (tx.amount < 0 ? 'expense' : 'income'),
             isCardPayment:
               tx.isCardPayment || tx.is_card_payment || tx.category === 'カード支払い',
+            category: tx.category || UNCATEGORIZED_LABEL,
           }));
         } catch {
           // ignore
@@ -170,7 +172,7 @@ function reducer(state, action) {
       const category = action.payload;
       const categories = state.categories.filter(c => c !== category);
       const transactions = state.transactions.map(tx =>
-        tx.category === category ? { ...tx, category: '' } : tx
+        tx.category === category ? { ...tx, category: UNCATEGORIZED_LABEL } : tx
       );
       const rules = state.rules.filter(rule => rule.category !== category);
       localStorage.setItem('lm_categories_v1', JSON.stringify(categories));


### PR DESCRIPTION
## Summary
- add UNCATEGORIZED_LABEL constant to represent uncategorized entries
- ensure StoreContext assigns UNCATEGORIZED_LABEL when category is missing or removed
- use UNCATEGORIZED_LABEL instead of "その他" for uncategorized transactions across pages and charts

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a02fd45e68832e81e9b1db46d259f3