### PR TITLE
feat: add theme settings and context

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import PasswordReset from './components/PasswordReset.jsx';
 import AmountVisual from './components/ui/AmountVisual.jsx';
 import { toast } from 'react-hot-toast';
 import { supabase } from './lib/supabaseClient.js';
+import { useTheme } from './state/ThemeContext.jsx';
 
 // shadcn/ui components
 import { Button } from './components/ui/button.jsx';
@@ -65,6 +66,7 @@ const Data = lazy(() => import('./pages/Data.jsx'));
 const SettingsHub = lazy(() => import('./pages/SettingsHub.jsx'));
 const DataSync = lazy(() => import('./pages/DataSync.jsx'));
 const Diagnostics = lazy(() => import('./pages/Diagnostics.jsx'));
+const ThemeSettings = lazy(() => import('./pages/ThemeSettings.jsx'));
 
 const NAV = {
   main: [
@@ -89,13 +91,14 @@ const NAV = {
 };
 
 const exists = k =>
-  [...NAV.main, ...NAV.data, ...NAV.settings].some(i => i.key === k) || ['dashboard', 'monthly', 'analysis', 'yearly', 'data', 'settings-hub', 'datasync', 'dbtest', 'conntest'].includes(k);
+  [...NAV.main, ...NAV.data, ...NAV.settings].some(i => i.key === k) || ['dashboard', 'monthly', 'analysis', 'yearly', 'data', 'settings-hub', 'datasync', 'dbtest', 'conntest', 'theme'].includes(k);
 
 function parseHash(hash) {
   const [raw, q = ''] = hash.replace(/^#/, '').split('?');
+  const path = raw.startsWith('/') ? raw.slice(1) : raw;
   const params = new URLSearchParams(q);
   return {
-    page: exists(raw) ? raw : undefined,
+    page: exists(path) ? path : undefined,
     period: params.get('period') || undefined,
     yenUnit: params.get('unit') || undefined,
     lockColors:
@@ -128,11 +131,21 @@ function serializeHash({
 export default function App() {
   const { state, dispatch, loadFromDatabase } = useStore();
   const { session, loading } = useSession();
+  const { theme } = useTheme();
   const isLocalMode = localStorage.getItem('localMode') === 'true';
   const [syncing, setSyncing] = useState(false);
 
   const isAuthenticated = session || isLocalMode;
   const isMobile = typeof window !== 'undefined' && window.innerWidth < 768;
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (theme === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+  }, [theme]);
 
   // 旧形式のfilterModeからrentを除去
   useEffect(() => {
@@ -1020,6 +1033,7 @@ function Dashboard({
             {page === 'prefs' && <Prefs />}
             {page === 'settings' && <Settings />}
             {page === 'diagnostics' && <Diagnostics />}
+            {page === 'theme' && <ThemeSettings />}
             {page === 'dbtest' && <DatabaseTest />}
             {page === 'conntest' && <ConnectionTest />}
           </Suspense>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App.jsx";
 import { StoreProvider } from "./state/StoreContextWithDB.jsx";
+import { ThemeProvider } from "./state/ThemeContext.jsx";
 import ErrorBoundary from "./ErrorBoundary.jsx";
 import { initErrorLogger } from "./errorLogger.js";
 import { Toaster } from "react-hot-toast";
@@ -12,8 +13,10 @@ initErrorLogger();
 createRoot(document.getElementById("root")).render(
   <ErrorBoundary>
     <StoreProvider>
-      <Toaster position="top-right" />
-      <App />
+      <ThemeProvider>
+        <Toaster position="top-right" />
+        <App />
+      </ThemeProvider>
     </StoreProvider>
   </ErrorBoundary>
 );

--- a/src/pages/SettingsHub.jsx
+++ b/src/pages/SettingsHub.jsx
@@ -104,7 +104,7 @@ export default function SettingsHub() {
       description: 'カラーテーマ、ダークモード、フォント設定',
       icon: Palette,
       color: 'pink',
-      href: '#prefs',
+      href: '#/theme',
       stats: {
         label: 'テーマ',
         value: 'ライトモード'

--- a/src/pages/ThemeSettings.jsx
+++ b/src/pages/ThemeSettings.jsx
@@ -1,0 +1,36 @@
+import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card.jsx';
+import { Button } from '../components/ui/button.jsx';
+import { Sun, Moon } from 'lucide-react';
+import { useTheme } from '../state/ThemeContext.jsx';
+
+export default function ThemeSettings() {
+  const { theme, setTheme } = useTheme();
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>テーマ設定</CardTitle>
+        </CardHeader>
+        <CardContent className="flex gap-4">
+          <Button
+            variant={theme === 'light' ? 'default' : 'outline'}
+            onClick={() => setTheme('light')}
+            className="flex-1"
+          >
+            <Sun className="h-4 w-4 mr-2" />
+            ライト
+          </Button>
+          <Button
+            variant={theme === 'dark' ? 'default' : 'outline'}
+            onClick={() => setTheme('dark')}
+            className="flex-1"
+          >
+            <Moon className="h-4 w-4 mr-2" />
+            ダーク
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/state/ThemeContext.jsx
+++ b/src/state/ThemeContext.jsx
@@ -1,0 +1,33 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+
+const ThemeContext = createContext();
+
+/**
+ * @param {{children: import('react').ReactNode}} props
+ */
+export function ThemeProvider({ children }) {
+  const [theme, setTheme] = useState(() => {
+    if (typeof window !== 'undefined') {
+      return localStorage.getItem('theme') || 'light';
+    }
+    return 'light';
+  });
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('theme', theme);
+    }
+  }, [theme]);
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error('useTheme must be used within ThemeProvider');
+  return ctx;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: ["./index.html", "./src/**/*.{js,jsx,ts,tsx}"],
   theme: { extend: {} },
   plugins: [],


### PR DESCRIPTION
## Summary
- add ThemeSettings page for light/dark toggle
- share theme across app via ThemeContext
- update SettingsHub and Tailwind config for new theme functionality

## Testing
- `npm run lint`
- `npx cypress run` *(fails: Cypress executable not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a03c4833a0832e9c853ceff8048c84