### PR TITLE
BarByMonthで100万円超は自動で万円表示に切り替え

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -657,7 +657,6 @@ function Dashboard({
             <BarByMonth
               transactions={filteredTransactions}
               period={period}
-              yenUnit={yenUnit}
               lockColors={lockColors}
               hideOthers={hideOthers}
               kind={kind}

--- a/src/BarByMonth.jsx
+++ b/src/BarByMonth.jsx
@@ -66,7 +66,6 @@ function ScrollableLegend({ payload }) {
 export default function BarByMonth({
   transactions,
   period,
-  yenUnit,
   lockColors,
   hideOthers,
   kind = 'expense',
@@ -133,29 +132,34 @@ const maxTotal = useMemo(() => {
     )
   );
 }, [dataWithMovingAvg]);
-
+  const displayUnit = useMemo(
+    () => (maxTotal >= 1_000_000 ? 'man' : 'yen'),
+    [maxTotal]
+  );
 
   const yAxisMax = useMemo(() => Math.ceil(maxTotal * 1.1), [maxTotal]);
 
   // Y軸のticksを自動計算（きりの良い数値で5つ程度に分割）
   const ticks = useMemo(() => {
-    if (yAxisMax === 0) return [0];
+    const divisor = displayUnit === 'man' ? 10000 : 1;
+    const max = yAxisMax / divisor;
+    if (max === 0) return [0];
 
     // 最大値を適切な間隔で分割
-    const step = Math.pow(10, Math.floor(Math.log10(yAxisMax)));
-    const normalizedMax = Math.ceil(yAxisMax / step) * step;
+    const step = Math.pow(10, Math.floor(Math.log10(max)));
+    const normalizedMax = Math.ceil(max / step) * step;
     const tickCount = 5;
     const tickStep = normalizedMax / tickCount;
 
     const result = [];
     for (let i = 0; i <= tickCount; i++) {
-      result.push(Math.round(tickStep * i));
+      result.push(Math.round(tickStep * i * divisor));
     }
     return result.filter(v => v <= yAxisMax);
-  }, [yAxisMax]);
+  }, [yAxisMax, displayUnit]);
 
-  const tickFormatter = (v) => formatAmount(v, yenUnit);
-  const formatValue = (v) => formatAmount(v, yenUnit);
+  const tickFormatter = (v) => formatAmount(v, displayUnit);
+  const formatValue = (v) => formatAmount(v, displayUnit);
   const legendPayload = dataWithColors.map((d) => ({
     id: d.month,
     value: d.month,

--- a/src/pages/MonthlyAnalysis.jsx
+++ b/src/pages/MonthlyAnalysis.jsx
@@ -18,7 +18,6 @@ export default function MonthlyAnalysis({
         <BarByMonth
           transactions={transactions}
           period={period}
-          yenUnit={yenUnit}
           lockColors={lockColors}
           hideOthers={hideOthers}
           kind="expense"

--- a/src/pages/Yearly.jsx
+++ b/src/pages/Yearly.jsx
@@ -134,7 +134,6 @@ export default function Yearly({
                   <BarByMonth
                     transactions={transactions}
                     period={period}
-                    yenUnit={yenUnit}
                     lockColors={lockColors}
                     hideOthers={hideOthers}
                     kind={kind}


### PR DESCRIPTION
## Summary
- `maxTotal` から自動的に表示単位を判定し、100万円以上は `man` に切り替え
- Y軸の目盛りやフォーマット処理を `displayUnit` ベースに統一
- 呼び出し側からの `yenUnit` 指定を削除し、表示単位をコンポーネント内部で一元管理

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a03cd2c21c832e93cf1f84d28c1bab