### PR TITLE
Apply saved rules immediately to transactions

### DIFF
--- a/src/pages/Transactions.jsx
+++ b/src/pages/Transactions.jsx
@@ -178,6 +178,7 @@ useEffect(() => {
     const rules = state.rules || [];
     const updatedRules = [...rules, newRule];
     dispatch({ type: 'setRules', payload: updatedRules });
+    dispatch({ type: 'applyRules' });
     
     // ルールのみを同期（トランザクションは同期しない）
     // 注：syncWithDatabaseはトランザクションとルールを両方同期するため、


### PR DESCRIPTION
## Summary
- apply rule immediately after saving on transaction page

## Testing
- `pnpm lint`
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a041560abc832e960b4f4fcdb75be7