### PR TITLE
fix: implement sheet context provider

### DIFF
--- a/src/components/ui/sheet.jsx
+++ b/src/components/ui/sheet.jsx
@@ -1,36 +1,26 @@
 import * as React from "react"
 import { cn } from "@/lib/utils"
 
+const SheetContext = React.createContext({})
+
 const Sheet = ({ children, open, onOpenChange }) => {
   React.useEffect(() => {
-    if (open) {
-      document.body.style.overflow = 'hidden'
-    } else {
-      document.body.style.overflow = 'unset'
-    }
-    
+    document.body.style.overflow = open ? 'hidden' : 'unset'
     return () => {
       document.body.style.overflow = 'unset'
     }
   }, [open])
 
-  if (!open) return null
-
   return (
-    <div className="fixed inset-0 z-50 pointer-events-none">
-      <div 
-        className="fixed inset-0" 
-        onClick={() => onOpenChange?.(false)}
-        style={{ pointerEvents: 'auto' }}
-      />
-      <div style={{ pointerEvents: 'auto' }}>
-        {children}
-      </div>
-    </div>
+    <SheetContext.Provider value={{ open, onOpenChange }}>
+      {children}
+    </SheetContext.Provider>
   )
 }
 
 const SheetContent = React.forwardRef(({ className, side = "right", children, ...props }, ref) => {
+  const { open, onOpenChange } = React.useContext(SheetContext)
+
   const sideClasses = {
     top: "top-0 left-0 right-0 h-auto max-h-[85vh] translate-y-[-100%] data-[state=open]:translate-y-0",
     bottom: "bottom-0 left-0 right-0 h-auto max-h-[85vh] translate-y-full data-[state=open]:translate-y-0",
@@ -38,21 +28,32 @@ const SheetContent = React.forwardRef(({ className, side = "right", children, ..
     right: "right-0 top-0 h-full w-3/4 max-w-sm translate-x-full data-[state=open]:translate-x-0"
   }
 
+  if (!open) return null
+
   return (
-    <div
-      ref={ref}
-      className={cn(
-        "fixed bg-white p-6 shadow-2xl transition-transform duration-300 ease-in-out border-l",
-        "data-[state=open]:translate-x-0 data-[state=open]:translate-y-0",
-        sideClasses[side],
-        className
-      )}
-      style={{ backgroundColor: 'white', color: '#1f2937' }}
-      data-state="open"
-      onClick={(e) => e.stopPropagation()}
-      {...props}
-    >
-      {children}
+    <div className="fixed inset-0 z-50 pointer-events-none">
+      <div
+        className="fixed inset-0"
+        onClick={() => onOpenChange?.(false)}
+        style={{ pointerEvents: 'auto' }}
+      />
+      <div style={{ pointerEvents: 'auto' }}>
+        <div
+          ref={ref}
+          className={cn(
+            "fixed bg-white p-6 shadow-2xl transition-transform duration-300 ease-in-out border-l",
+            "data-[state=open]:translate-x-0 data-[state=open]:translate-y-0",
+            sideClasses[side],
+            className
+          )}
+          style={{ backgroundColor: 'white', color: '#1f2937' }}
+          data-state={open ? "open" : "closed"}
+          onClick={(e) => e.stopPropagation()}
+          {...props}
+        >
+          {children}
+        </div>
+      </div>
     </div>
   )
 })
@@ -85,15 +86,31 @@ const SheetDescription = React.forwardRef(({ className, ...props }, ref) => (
 ))
 SheetDescription.displayName = "SheetDescription"
 
-const SheetTrigger = React.forwardRef(({ className, children, ...props }, ref) => (
-  <button
-    ref={ref}
-    className={cn(className)}
-    {...props}
-  >
-    {children}
-  </button>
-))
+const SheetTrigger = React.forwardRef(({ className, asChild, children, ...props }, ref) => {
+  const { onOpenChange } = React.useContext(SheetContext)
+
+  if (asChild && React.isValidElement(children)) {
+    return React.cloneElement(children, {
+      ref,
+      onClick: (e) => {
+        children.props.onClick?.(e)
+        onOpenChange?.(true)
+      },
+      ...props,
+    })
+  }
+
+  return (
+    <button
+      ref={ref}
+      className={cn(className)}
+      onClick={() => onOpenChange?.(true)}
+      {...props}
+    >
+      {children}
+    </button>
+  )
+})
 SheetTrigger.displayName = "SheetTrigger"
 
 export {


### PR DESCRIPTION
## Summary
- add context provider for Sheet to manage open state
- support trigger cloning and overlay rendering in SheetContent

## Testing
- `pnpm lint`
- `pnpm dev`

------
https://chatgpt.com/codex/tasks/task_e_68a043bd57b4832e938be269a45b1e38