### PR TITLE
fix: validate and spread class name inputs

### DIFF
--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -2,5 +2,9 @@ import { clsx } from "clsx"
 import { twMerge } from "tailwind-merge"
 
 export function cn(...inputs) {
-  return twMerge(clsx(inputs))
+  if (!inputs.every((input) => typeof input === "string")) {
+    return ""
+  }
+
+  return twMerge(clsx(...inputs))
 }


### PR DESCRIPTION
## Summary
- spread inputs for clsx in cn util
- return empty string when non-string input is provided

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68a046c5ecd0832e8606b45319067a95