### PR TITLE
feat: add supabase env fallback and docs

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -18,6 +18,16 @@ npm run dev
   - `VITE_SUPABASE_URL`: Supabase プロジェクトの URL
   - `VITE_SUPABASE_ANON_KEY`: Supabase の anon key
 
+#### 環境変数の設定例
+
+```
+VITE_SUPABASE_URL=https://xxxx.supabase.co
+VITE_SUPABASE_ANON_KEY=your-anon-key
+```
+
+これらの環境変数が未設定の場合、`src/lib/supabaseClient.js` は警告を出して `null` を返し、
+Supabase を利用する機能は無効になります。
+
 ## 開発用コマンド
 
 | コマンド | 説明 |

--- a/src/lib/supabaseClient.js
+++ b/src/lib/supabaseClient.js
@@ -1,24 +1,27 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
-
-console.log('Supabase Configuration:', {
-  url: supabaseUrl ? `${supabaseUrl.substring(0, 30)}...` : 'Not set',
-  key: supabaseAnonKey ? `${supabaseAnonKey.substring(0, 20)}...` : 'Not set',
-  env: import.meta.env.MODE
-});
-
 /**
- * Shared Supabase client instance.
- * Configured using environment variables.
- * @type {import('@supabase/supabase-js').SupabaseClient | null}
+ * Initialize a Supabase client using environment variables.
+ * Returns null when configuration is missing so callers can branch.
+ * @returns {import('@supabase/supabase-js').SupabaseClient | null}
  */
-let supabase = null;
+function createSupabaseClient() {
+  const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+  const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
-try {
-  if (supabaseUrl && supabaseAnonKey) {
-    supabase = createClient(supabaseUrl, supabaseAnonKey, {
+  console.log('Supabase Configuration:', {
+    url: supabaseUrl ? `${supabaseUrl.substring(0, 30)}...` : 'Not set',
+    key: supabaseAnonKey ? `${supabaseAnonKey.substring(0, 20)}...` : 'Not set',
+    env: import.meta.env.MODE
+  });
+
+  if (!supabaseUrl || !supabaseAnonKey) {
+    console.warn('Supabase environment variables are missing');
+    return null;
+  }
+
+  try {
+    const client = createClient(supabaseUrl, supabaseAnonKey, {
       auth: {
         autoRefreshToken: true,
         persistSession: true,
@@ -27,11 +30,14 @@ try {
       }
     });
     console.log('Supabase client initialized successfully');
-  } else {
-    console.warn('Supabase environment variables are missing');
+    return client;
+  } catch (error) {
+    console.error('Failed to initialize Supabase client:', error);
+    return null;
   }
-} catch (error) {
-  console.error('Failed to initialize Supabase client:', error);
 }
 
+const supabase = createSupabaseClient();
+
 export { supabase };
+


### PR DESCRIPTION
## Summary
- return `null` when Supabase env vars are missing so callers can handle absence
- document required Supabase environment variables and how to set them

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68a046cf1890832e8f03a9d3911f36c7